### PR TITLE
Fix boolean

### DIFF
--- a/gmagick_methods.c
+++ b/gmagick_methods.c
@@ -196,9 +196,9 @@ PHP_METHOD(gmagick, writeimage)
 	}
 	
 	if (all_frames) {
-		status = MagickWriteImage(intern->magick_wand, filename);
-	} else {
 		status = MagickWriteImages(intern->magick_wand, filename, MagickTrue);
+	} else {
+		status = MagickWriteImage(intern->magick_wand, filename);
 	}
 	
 	if (status == MagickFalse) {


### PR DESCRIPTION
Swap boolean direction -- In Imagemagick a "true" argument writes "all frames" -- In graphicsmagick, it's documented the same way, but the functionality is swapped.