### PR TITLE
Added test for readImageBlob

### DIFF
--- a/tests/gmagick-105-readimageblob.phpt
+++ b/tests/gmagick-105-readimageblob.phpt
@@ -1,0 +1,25 @@
+--TEST--
+setImagePage test
+--SKIPIF--
+<?php
+if(!extension_loaded('gmagick')) die('skip');
+?>
+--FILE--
+<?php
+$image = new Gmagick('magick:rose');
+$image->setImageFormat('png');
+$imageBlob = $image->getImageBlob();
+
+$imageReload = new Gmagick();
+$imageReload->readImageBlob($imageBlob);
+printf(
+    "Dimensions are %d x %d\n",
+    $imageReload->getImageWidth(),
+    $imageReload->getImageHeight()
+);
+echo "ok";
+
+?>
+--EXPECTF--
+Dimensions are 70 x 46
+ok


### PR DESCRIPTION
Which also covers https://bugs.php.net/bug.php?id=59464

FUN-FACT!* Graphics Magick does not always rebuild the GraphicsMagick-config program, which can lead to writing simple test cases like this taking way more time than they should, because the linking depends on the GraphicsMagick-config being up-to-date!

  
  
  
  
  
  
  
  
  
  
\* Actual amount of fun may vary.