### PR TITLE
zend_long for parse parameters

### DIFF
--- a/gmagick_helpers.c
+++ b/gmagick_helpers.c
@@ -620,7 +620,6 @@ void s_calculate_crop(
 */
 zend_bool crop_thumbnail_image(MagickWand *magick_wand, long desired_width, long desired_height, zend_bool legacy TSRMLS_DC)
 {
-	double ratio_x, ratio_y;
 	long offset_x = 0, offset_y = 0, new_width, new_height;
 
 	long orig_width  = MagickGetImageWidth(magick_wand);
@@ -660,10 +659,10 @@ zend_bool crop_thumbnail_image(MagickWand *magick_wand, long desired_width, long
 
 /** zend_bool php_gmagick_thumbnail_dimensions(MagickWand *magick_wand, zend_bool bestfit, long desired_width, long desired_height, long *new_width, long *new_height)
 */
-zend_bool php_gmagick_thumbnail_dimensions(MagickWand *magick_wand, zend_bool bestfit, long desired_width, long desired_height, long *new_width, long *new_height, zend_bool legacy)
+zend_bool php_gmagick_thumbnail_dimensions(MagickWand *magick_wand, zend_bool bestfit, zend_long desired_width, zend_long desired_height, zend_long *new_width, zend_long *new_height, zend_bool legacy)
 {
-	long orig_width, orig_height;
-	
+	zend_long orig_width, orig_height;
+
 	orig_width  = MagickGetImageWidth(magick_wand); 
 	orig_height = MagickGetImageHeight(magick_wand);
 	
@@ -689,7 +688,7 @@ zend_bool php_gmagick_thumbnail_dimensions(MagickWand *magick_wand, zend_bool be
 				*new_height = ratio_x * (double)orig_height;
 			}
 			else {
-				*new_height = gm_round_helper(ratio_x * ((double) orig_height));
+				*new_height = gm_round_helper_class(ratio_x * ((double) orig_height));
 			}
 		} else { 
 			*new_height = desired_height; 
@@ -698,7 +697,7 @@ zend_bool php_gmagick_thumbnail_dimensions(MagickWand *magick_wand, zend_bool be
 				*new_width  = ratio_y * (double)orig_width;
 			}
 			else {
-				*new_width  = gm_round_helper(ratio_y * ((double) orig_width));
+				*new_width  = gm_round_helper_class(ratio_y * ((double) orig_width));
 			}
 		} 
 		
@@ -719,7 +718,7 @@ zend_bool php_gmagick_thumbnail_dimensions(MagickWand *magick_wand, zend_bool be
 					*new_width  = orig_width / ratio;
 				}
 				else {
-					*new_width  = gm_round_helper(((double) orig_width) / ratio);
+					*new_width  = gm_round_helper_class(((double) orig_width) / ratio);
 				}
 
 				*new_height = desired_height;
@@ -729,7 +728,7 @@ zend_bool php_gmagick_thumbnail_dimensions(MagickWand *magick_wand, zend_bool be
 					*new_height = orig_height / ratio;
 				}
 				else {
-					*new_height = gm_round_helper(((double) orig_height) / ratio);
+					*new_height = gm_round_helper_class(((double) orig_height) / ratio);
 				}
 				*new_width  = desired_width;
 			}

--- a/gmagick_methods.c
+++ b/gmagick_methods.c
@@ -36,7 +36,7 @@ static MagickBool SafeModeMonitor(const ConfirmAccessMode mode,
 #endif	
 	return MagickPass;
 }
-#endif
+
 static MagickBool OpenBaseDirMonitor(const ConfirmAccessMode mode,
 					const char *path,
 					ExceptionInfo *exception)
@@ -47,7 +47,8 @@ static MagickBool OpenBaseDirMonitor(const ConfirmAccessMode mode,
 	}
 	return MagickPass;
 }
-#endif
+#endif //#if PHP_VERSION_ID < 50399
+#endif //#if GMAGICK_LIB_MASK >= 1004000
 
 /* {{{ Gmagick Gmagick::read(string filename)
 	Reads image
@@ -146,7 +147,7 @@ PHP_METHOD(gmagick, blurimage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd|l", &radius, &sigma) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &radius, &sigma) == FAILURE) {
 		return;
 	}
 
@@ -216,12 +217,12 @@ PHP_METHOD(gmagick, writeimage)
 */
 PHP_METHOD(gmagick, thumbnailimage)
 {
-	long columns, rows, width, height;
+	zend_long columns, rows, width, height;
 	php_gmagick_object *intern;
 	zend_bool fit = 0;
 	zend_bool legacy = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll|bl", &columns, &rows, &fit, &legacy) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll|bb", &columns, &rows, &fit, &legacy) == FAILURE) {
 		return;
 	}
 
@@ -251,12 +252,12 @@ PHP_METHOD(gmagick, thumbnailimage)
 PHP_METHOD(gmagick, resizeimage)
 {
 	double blur;
-	long width, height, new_width, new_height, filter = 0;
+	zend_long width, height, new_width, new_height, filter = 0;
 	php_gmagick_object *intern;
 	zend_bool fit = 0;
 	zend_bool legacy = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "llld|bl", &width, &height, &filter, &blur, &fit, &legacy) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "llld|bb", &width, &height, &filter, &blur, &fit, &legacy) == FAILURE) {
 		return;
 	}
 
@@ -335,12 +336,12 @@ PHP_METHOD(gmagick, cropimage)
 */
 PHP_METHOD(gmagick, cropthumbnailimage)
 {
-	long crop_width, crop_height;
+	zend_long crop_width, crop_height;
 	zend_bool legacy = 0;
 	php_gmagick_object *intern;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll|l", &crop_width, &crop_height, &legacy) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll|b", &crop_width, &crop_height, &legacy) == FAILURE) {
 		return;
 	}
 
@@ -394,7 +395,7 @@ PHP_METHOD(gmagick, compositeimage)
 {
 	zval *source_obj;
 	php_gmagick_object *source, *intern;
-	long x, y, compose;
+	zend_long x, y, compose;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Olll", &source_obj, php_gmagick_sc_entry, &compose, &x, &y) == FAILURE) {
 		return;
@@ -485,7 +486,7 @@ PHP_METHOD(gmagick, addnoiseimage)
 {
 	php_gmagick_object *intern;
 	MagickBool status;
-	long noise;
+	zend_long noise;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &noise) == FAILURE) {
 		return;
@@ -514,7 +515,7 @@ PHP_METHOD(gmagick, borderimage)
 	php_gmagick_object *intern;
 	php_gmagickpixel_object *internp;
 	MagickBool status;
-	long width, height;
+	zend_long width, height;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zll", &param, &width, &height) == FAILURE) {
 		return;
@@ -544,7 +545,7 @@ PHP_METHOD(gmagick, thresholdimage)
 	php_gmagick_object *intern;
 	double threshold;
 	MagickBool status;
-	long channel = DefaultChannels;
+	zend_long channel = DefaultChannels;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d|l", &threshold, &channel) == FAILURE) {
 		return;
@@ -599,7 +600,7 @@ PHP_METHOD(gmagick, charcoalimage)
 PHP_METHOD(gmagick, chopimage)
 {
 	php_gmagick_object *intern;
-	long width, height, x, y;
+	zend_long width, height, x, y;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -667,7 +668,7 @@ PHP_METHOD(gmagick, current)
 PHP_METHOD(gmagick, cyclecolormapimage)
 {
 	php_gmagick_object *intern;
-	long displace;
+	zend_long displace;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -711,7 +712,7 @@ PHP_METHOD(gmagick, deconstructimages)
 	}
 
 	object_init_ex(return_value, php_gmagick_sc_entry);
-	intern = Z_GMAGICK_OBJ_P(return_value);
+	intern_return = Z_GMAGICK_OBJ_P(return_value);
 	GMAGICK_REPLACE_MAGICKWAND(intern_return, tmp_wand);
 
 	return;
@@ -941,7 +942,7 @@ PHP_METHOD(gmagick, frameimage)
 	php_gmagick_object *intern;
 	php_gmagickpixel_object *internp;
 	MagickBool status;
-	long width, height, inner_bevel, outer_bevel;
+	zend_long width, height, inner_bevel, outer_bevel;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zllll", &param, &width, &height, &inner_bevel, &outer_bevel) == FAILURE) {
 		return;
@@ -1247,7 +1248,7 @@ PHP_METHOD(gmagick, getimagebordercolor)
 PHP_METHOD(gmagick, getimagechanneldepth)
 {
 	php_gmagick_object *intern;
-	long channel_type, channel_depth;
+	zend_long channel_type, channel_depth;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &channel_type) == FAILURE) {
@@ -1324,7 +1325,7 @@ PHP_METHOD(gmagick, setimagebordercolor)
 PHP_METHOD(gmagick, setimagechanneldepth)
 {
 	php_gmagick_object *intern;
-	long channel_type, depth;
+	zend_long channel_type, depth;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -1351,7 +1352,7 @@ PHP_METHOD(gmagick, setimagechanneldepth)
 PHP_METHOD(gmagick, setimagecolorspace)
 {
 	php_gmagick_object *intern;
-	long colorspace;
+	zend_long colorspace;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -1378,7 +1379,7 @@ PHP_METHOD(gmagick, setimagecolorspace)
 PHP_METHOD(gmagick, setinterlacescheme)
 {
 	php_gmagick_object *intern;
-	long schema;
+	zend_long schema;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -1521,7 +1522,7 @@ PHP_METHOD(gmagick, getnumberimages)
 PHP_METHOD(gmagick, setimagecompose)
 {
 	php_gmagick_object *intern;
-	long compose;
+	zend_long compose;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -1548,7 +1549,7 @@ PHP_METHOD(gmagick, setimagecompose)
 PHP_METHOD(gmagick, setimagecompression)
 {
 	php_gmagick_object *intern;
-	long compression;
+	zend_long compression;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -1595,7 +1596,7 @@ PHP_METHOD(gmagick, getimagecompression)
 PHP_METHOD(gmagick, setimagedelay)
 {
 	php_gmagick_object *intern;
-	long delay;
+	zend_long delay;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -1622,7 +1623,7 @@ PHP_METHOD(gmagick, setimagedelay)
 PHP_METHOD(gmagick, setimagedepth)
 {
 	php_gmagick_object *intern;
-	long depth;
+	zend_long depth;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -1669,7 +1670,7 @@ PHP_METHOD(gmagick, getimagedispose)
 PHP_METHOD(gmagick, setimagedispose)
 {
 	php_gmagick_object *intern;
-	long dispose;
+	zend_long dispose;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -1927,7 +1928,7 @@ PHP_METHOD(gmagick, setimageformat)
 PHP_METHOD(gmagick, setcompressionquality)
 {
 	php_gmagick_object *intern;
-	long compression_quality;
+	zend_long compression_quality;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -2133,7 +2134,7 @@ PHP_METHOD(gmagick, getimageindex)
 */
 PHP_METHOD(gmagick, setimageindex)
 {
-	long index;
+	zend_long index;
 	MagickBool status;
 	php_gmagick_object *intern;
 
@@ -2182,7 +2183,7 @@ PHP_METHOD(gmagick, getimageinterlacescheme)
 PHP_METHOD(gmagick, setimageinterlacescheme)
 {
 	php_gmagick_object *intern;
-	long interlace;
+	zend_long interlace;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -2526,7 +2527,7 @@ PHP_METHOD(gmagick, getimagetype)
 PHP_METHOD(gmagick, setimageiterations)
 {
 	php_gmagick_object *intern;
-	long iterations;
+	zend_long iterations;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -2609,7 +2610,7 @@ PHP_METHOD(gmagick, setimageredprimary)
 PHP_METHOD(gmagick, setimagerenderingintent)
 {
 	php_gmagick_object *intern;
-	long rendering_intent;
+	zend_long rendering_intent;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -2663,7 +2664,7 @@ PHP_METHOD(gmagick, setimageresolution)
 PHP_METHOD(gmagick, setimagescene)
 {
 	php_gmagick_object *intern;
-	long scene;
+	zend_long scene;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -2690,7 +2691,7 @@ PHP_METHOD(gmagick, setimagescene)
 PHP_METHOD(gmagick, setimagetype)
 {
 	php_gmagick_object *intern;
-	long image_type;
+	zend_long image_type;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -2718,7 +2719,7 @@ PHP_METHOD(gmagick, setimagetype)
 PHP_METHOD(gmagick, setimagepage)
 {
 	php_gmagick_object *intern;
-	long width, height, x, y;
+	zend_long width, height, x, y;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -2875,7 +2876,7 @@ PHP_METHOD(gmagick, getreleasedate)
 */
 PHP_METHOD(gmagick, getresourcelimit)
 {
-	long resource_type;
+	zend_long resource_type;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &resource_type) == FAILURE) {
 		return;
@@ -2946,7 +2947,7 @@ PHP_METHOD(gmagick, getsize)
 PHP_METHOD(gmagick, setimageunits)
 {
 	php_gmagick_object *intern;
-	long units;
+	zend_long units;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -3038,7 +3039,7 @@ PHP_METHOD(gmagick, setsamplingfactors)
 PHP_METHOD(gmagick, setresourcelimit)
 {
 	MagickBool status;
-	long type, limit;
+	zend_long type, limit;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll", &type, &limit) == FAILURE) {
@@ -3061,7 +3062,7 @@ PHP_METHOD(gmagick, setresourcelimit)
 PHP_METHOD(gmagick, setsize)
 {
 	php_gmagick_object *intern;
-	long columns, rows;
+	zend_long columns, rows;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -3215,7 +3216,7 @@ PHP_METHOD(gmagick, levelimage)
 	php_gmagick_object *intern;
 	double black_point, gamma, white_point;
 	MagickBool status;
-	long channel = DefaultChannels;
+	zend_long channel = DefaultChannels;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ddd|l", &black_point, &gamma, &white_point, &channel) == FAILURE) {
@@ -3329,7 +3330,7 @@ PHP_METHOD(gmagick, negateimage)
 	php_gmagick_object *intern;
 	zend_bool gray;
 	MagickBool status;
-	long channel = DefaultChannels;
+	zend_long channel = DefaultChannels;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "b|l", &gray, &channel) == FAILURE) {
@@ -3462,7 +3463,7 @@ PHP_METHOD(gmagick, nextimage)
 PHP_METHOD(gmagick, newimage)
 {
 	php_gmagick_object *intern;
-	long columns, rows;
+	zend_long columns, rows;
 	char *param;
 	size_t param_len = 0;
 	char *format = NULL;
@@ -3503,7 +3504,7 @@ PHP_METHOD(gmagick, normalizeimage)
 {
 	MagickBool status;
 	php_gmagick_object *intern;
-	long channel;
+	zend_long channel;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|l", &channel) == FAILURE) {
@@ -3611,7 +3612,7 @@ PHP_METHOD(gmagick, profileimage)
 PHP_METHOD(gmagick, quantizeimage)
 {
 	php_gmagick_object *intern;
-	long number_colors, colorspace, tree_depth;
+	zend_long number_colors, colorspace, tree_depth;
 	zend_bool dither, measure_error;
 	MagickBool status;
 
@@ -3641,7 +3642,7 @@ PHP_METHOD(gmagick, quantizeimage)
 PHP_METHOD(gmagick, quantizeimages)
 {
 	php_gmagick_object *intern;
-	long number_colors, colorspace, tree_depth;
+	zend_long number_colors, colorspace, tree_depth;
 	zend_bool dither, measure_error;
 	MagickBool status;
 
@@ -3769,7 +3770,7 @@ PHP_METHOD(gmagick, radialblurimage)
 	php_gmagick_object *intern;
 	MagickBool status;
 	double angle;
-	long channel = DefaultChannels;
+	zend_long channel = DefaultChannels;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d|l", &angle, &channel) == FAILURE) {
 		return;
@@ -3799,7 +3800,7 @@ PHP_METHOD(gmagick, raiseimage)
 {
 	php_gmagick_object *intern;
 	MagickBool status;
-	long width, height, x, y;
+	zend_long width, height, x, y;
 	zend_bool raise;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "llllb", &width, &height, &x, &y, &raise) == FAILURE) {
@@ -3984,7 +3985,7 @@ PHP_METHOD(gmagick, removeimageprofile)
 PHP_METHOD(gmagick, resampleimage)
 {
 	double xRes, yRes, blur;
-	long filter = 0;
+	zend_long filter = 0;
 	php_gmagick_object *intern;
 	MagickBool status;
 
@@ -4010,7 +4011,7 @@ PHP_METHOD(gmagick, resampleimage)
 */
 PHP_METHOD(gmagick, rollimage)
 {
-	long x, y;
+	zend_long x, y;
 	php_gmagick_object *intern;
 	MagickBool status;
 
@@ -4070,14 +4071,14 @@ PHP_METHOD(gmagick, rotateimage)
 */
 PHP_METHOD(gmagick, scaleimage)
 {
-	long x, y, width, height;
+	zend_long x, y, width, height;
 	php_gmagick_object *intern;
 	MagickBool status;
 	zend_bool fit = 0;
 	zend_bool legacy = 0;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll|bl", &x, &y, &fit, &legacy) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll|bb", &x, &y, &fit, &legacy) == FAILURE) {
 		return;
 	}
 
@@ -4106,7 +4107,7 @@ PHP_METHOD(gmagick, scaleimage)
 PHP_METHOD(gmagick, separateimagechannel)
 {
 	php_gmagick_object *intern;
-	long channel;
+	zend_long channel;
 	MagickBool status;
 
 	/* Parse parameters given to function */
@@ -4137,7 +4138,7 @@ PHP_METHOD(gmagick, sharpenimage)
 	php_gmagick_object *intern;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd|l", &radius, &sigma) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &radius, &sigma) == FAILURE) {
 		return;
 	}
 	
@@ -4192,7 +4193,7 @@ PHP_METHOD(gmagick, solarizeimage)
 {
 	php_gmagick_object *intern;
 	MagickBool status;
-	long threshold;
+	zend_long threshold;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &threshold) == FAILURE) {
 		return;
@@ -4434,14 +4435,14 @@ PHP_METHOD(gmagick, flattenimages)
 */
 PHP_METHOD(gmagick, sampleimage)
 {
-	long x, y, width, height;
+	zend_long x, y, width, height;
 	php_gmagick_object *intern;
 	MagickBool status;
 	zend_bool fit = 0;
 	zend_bool legacy = 0;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll|bl", &x, &y, &fit, &legacy) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll|bb", &x, &y, &fit, &legacy) == FAILURE) {
 		return;
 	}
 

--- a/gmagickdraw_methods.c
+++ b/gmagickdraw_methods.c
@@ -754,7 +754,7 @@ PHP_METHOD(gmagickdraw, setfontsize)
 PHP_METHOD(gmagickdraw, setfontstyle)
 {
 	php_gmagickdraw_object *internd;
-	long style_id = AnyStyle;
+	zend_long style_id = AnyStyle;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &style_id) == FAILURE) {
@@ -774,7 +774,7 @@ PHP_METHOD(gmagickdraw, setfontstyle)
 PHP_METHOD(gmagickdraw, setfontweight)
 {
 	php_gmagickdraw_object *internd;
-	long weight;
+	zend_long weight;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &weight) == FAILURE) {
@@ -820,7 +820,7 @@ PHP_METHOD(gmagickdraw, setstrokeopacity)
 PHP_METHOD(gmagickdraw, settextdecoration)
 {
 	php_gmagickdraw_object *internd;
-	long decoration;
+	zend_long decoration;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &decoration) == FAILURE) {
@@ -841,7 +841,7 @@ PHP_METHOD(gmagickdraw, settextdecoration)
 PHP_METHOD(gmagickdraw, setgravity)
 {
 	php_gmagickdraw_object *internd;
-	long gravity;
+	zend_long gravity;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &gravity) == FAILURE) {
 		return;
@@ -939,7 +939,7 @@ PHP_METHOD(gmagickdraw, setstrokedashoffset)
 PHP_METHOD(gmagickdraw, setstrokelinecap)
 {
 	php_gmagickdraw_object *internd;
-	long line_cap;
+	zend_long line_cap;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &line_cap) == FAILURE) {
@@ -959,7 +959,7 @@ PHP_METHOD(gmagickdraw, setstrokelinecap)
 PHP_METHOD(gmagickdraw, setstrokelinejoin)
 {	
 	php_gmagickdraw_object *internd;
-	long line_join;
+	zend_long line_join;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &line_join) == FAILURE) {
@@ -979,7 +979,7 @@ PHP_METHOD(gmagickdraw, setstrokelinejoin)
 PHP_METHOD(gmagickdraw, setstrokemiterlimit)
 {
 	php_gmagickdraw_object *internd;
-	long miter_limit;
+	zend_long miter_limit;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &miter_limit) == FAILURE) {
@@ -1247,7 +1247,7 @@ PHP_METHOD(gmagickdraw, getcliprule)
 PHP_METHOD(gmagickdraw, setcliprule)
 {
 	php_gmagickdraw_object *internd;
-	long fill_rule;
+	zend_long fill_rule;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &fill_rule) == FAILURE) {
@@ -1286,7 +1286,7 @@ PHP_METHOD(gmagickdraw, getclipunits)
 PHP_METHOD(gmagickdraw, setclipunits)
 {	
 	php_gmagickdraw_object *internd;
-	long units;
+	zend_long units;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &units) == FAILURE) {
@@ -1390,7 +1390,7 @@ PHP_METHOD(gmagickdraw, getfillrule)
 PHP_METHOD(gmagickdraw, setfillrule)
 {
 	php_gmagickdraw_object *internd;
-	long fill_rule;
+	zend_long fill_rule;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &fill_rule) == FAILURE) {
@@ -1503,7 +1503,7 @@ PHP_METHOD(gmagickdraw, getfontstretch)
 PHP_METHOD(gmagickdraw, setfontstretch)
 {
 	php_gmagickdraw_object *internd;
-	long stretch;
+	zend_long stretch;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &stretch) == FAILURE) {
@@ -2270,7 +2270,7 @@ PHP_METHOD(gmagickdraw, translate)
 PHP_METHOD(gmagickdraw, setviewbox)
 {
 	php_gmagickdraw_object *internd;
-	long x1, y1, x2, y2;
+	zend_long x1, y1, x2, y2;
 
 	/* Parse parameters given to function */
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "llll", &x1, &y1, &x2, &y2) == FAILURE) {

--- a/gmagickpixel_methods.c
+++ b/gmagickpixel_methods.c
@@ -148,7 +148,7 @@ PHP_METHOD(gmagickpixel, getcolorcount)
 PHP_METHOD(gmagickpixel, getcolorvalue)
 {
 	php_gmagickpixel_object *internp;
-	long color;
+	zend_long color;
 	double color_value = 0;
 
 	/* Parse parameters given to function */
@@ -206,7 +206,7 @@ PHP_METHOD(gmagickpixel, getcolorvalue)
 PHP_METHOD(gmagickpixel, setcolorvalue)
 {
 	php_gmagickpixel_object *internp;
-	long color;
+	zend_long color;
 	double color_value;
 
 	/* Parse parameters given to function */

--- a/php_gmagick_helpers.h
+++ b/php_gmagick_helpers.h
@@ -44,7 +44,7 @@ zend_bool crop_thumbnail_image(MagickWand *magick_wand, long desired_width, long
 
 /* {{{ zend_bool php_gmagick_thumbnail_dimensions(MagickWand *magick_wand, zend_bool bestfit, long desired_width, long desired_height, long *new_width, long *new_height)
 */
-zend_bool php_gmagick_thumbnail_dimensions(MagickWand *magick_wand, zend_bool bestfit, long desired_width, long desired_height, long *new_width, long *new_height, zend_bool legacy);
+zend_bool php_gmagick_thumbnail_dimensions(MagickWand *magick_wand, zend_bool bestfit, zend_long desired_width, zend_long desired_height, zend_long *new_width, zend_long *new_height, zend_bool legacy);
 
 /* {{{ zend_bool php_gmagick_ensure_not_empty (MagickWand *magick_wand) */
 zend_bool php_gmagick_ensure_not_empty (MagickWand *magick_wand);


### PR DESCRIPTION
Corrected long -> zend_long which apparently is needed for PHP 7 builds on some platforms.

I believe it is for 32 bit builds as for them long is 32bits whereas for PHP 7, PHPs "int" type is now consistently 64bit. And yes, this is not listed in the upgrade notes for PHP 7.

Also removed an extraneous parameter for blurimage and sharpenimage, which probably ought to be in the changelog.
