### PR TITLE
Added get/setColorValueQuantum

### DIFF
--- a/gmagick.c
+++ b/gmagick.c
@@ -1620,11 +1620,20 @@ ZEND_BEGIN_ARG_INFO_EX(gmagickpixel_getcolorvalue_args, 0, 0, 1)
 	ZEND_ARG_INFO(0, color)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(gmagickpixel_getcolorvaluequantum_args, 0, 0, 1)
+	ZEND_ARG_INFO(0, color)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(gmagickpixel_setcolor_args, 0, 0, 1)
 	ZEND_ARG_INFO(0, color)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(gmagickpixel_setcolorvalue_args, 0, 0, 2)
+	ZEND_ARG_INFO(0, color)
+	ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(gmagickpixel_setcolorvaluequantum_args, 0, 0, 2)
 	ZEND_ARG_INFO(0, color)
 	ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
@@ -1639,6 +1648,8 @@ static zend_function_entry php_gmagickpixel_class_methods[] =
 	PHP_ME(gmagickpixel,	getcolorcount,		gmagickpixel_zero_args,		ZEND_ACC_PUBLIC)
 	PHP_ME(gmagickpixel,	getcolorvalue,		gmagickpixel_getcolorvalue_args,	ZEND_ACC_PUBLIC)
 	PHP_ME(gmagickpixel,	setcolorvalue,		gmagickpixel_setcolorvalue_args,	ZEND_ACC_PUBLIC)
+	PHP_ME(gmagickpixel,	getcolorvaluequantum,		gmagickpixel_getcolorvaluequantum_args,	ZEND_ACC_PUBLIC)
+	PHP_ME(gmagickpixel,	setcolorvaluequantum,		gmagickpixel_setcolorvaluequantum_args,	ZEND_ACC_PUBLIC)
 	{ NULL, NULL, NULL }
 };
 /* }}} */

--- a/gmagickpixel_methods.c
+++ b/gmagickpixel_methods.c
@@ -258,3 +258,125 @@ PHP_METHOD(gmagickpixel, setcolorvalue)
 	GMAGICK_CHAIN_METHOD;
 }
 /* }}} */
+
+/* {{{ proto float GmagickPixel::getColorValueQuantum(int color )
+	Gets the quantum color of the GmagickPixel.
+*/
+PHP_METHOD(gmagickpixel, getcolorvaluequantum)
+{
+	php_gmagickpixel_object *internp;
+	zend_long colorquantum;
+	double color_value_quantum = 0;
+
+	/* Parse parameters given to function */
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &colorquantum) == FAILURE) {
+		return;
+	}
+
+	internp = Z_GMAGICKPIXEL_OBJ_P(getThis());
+
+	switch (colorquantum) {
+
+		case GMAGICK_COLOR_BLACK:
+			color_value_quantum = PixelGetBlackQuantum(internp->pixel_wand);
+			break;
+
+		case GMAGICK_COLOR_BLUE:
+			color_value_quantum = PixelGetBlueQuantum(internp->pixel_wand);
+			break;
+
+		case GMAGICK_COLOR_CYAN:
+			color_value_quantum = PixelGetCyanQuantum(internp->pixel_wand);
+			break;
+
+		case GMAGICK_COLOR_GREEN:
+			color_value_quantum = PixelGetGreenQuantum(internp->pixel_wand);
+			break;
+
+		case GMAGICK_COLOR_RED:
+			color_value_quantum = PixelGetRedQuantum(internp->pixel_wand);
+			break;
+
+		case GMAGICK_COLOR_YELLOW:
+			color_value_quantum = PixelGetYellowQuantum(internp->pixel_wand);
+			break;
+
+		case GMAGICK_COLOR_MAGENTA:
+			color_value_quantum = PixelGetMagentaQuantum(internp->pixel_wand);
+			break;
+
+		case GMAGICK_COLOR_OPACITY:
+			color_value_quantum = PixelGetOpacityQuantum(internp->pixel_wand);
+			break;
+
+		default:
+			GMAGICK_THROW_GMAGICKPIXEL_EXCEPTION(internp->pixel_wand, "Unknown color type");
+			break;
+	}
+	RETVAL_DOUBLE(color_value_quantum);
+}
+/* }}} */
+
+/* {{{ proto GmagickPixel GmagickPixel::setColorValueQuantum(int color, float value)
+	Sets the normalized color quantum of the GmagickPixel.
+*/
+PHP_METHOD(gmagickpixel, setcolorvaluequantum)
+{
+	php_gmagickpixel_object *internp;
+	zend_long color_quantum;
+	double color_value_quantum_i;
+	Quantum color_value_quantum;
+	char r[100];
+
+	/* Parse parameters given to function */
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ld", &color_quantum, &color_value_quantum_i) == FAILURE) {
+		return;
+	}
+
+	// Possible truncation?
+	color_value_quantum = color_value_quantum_i;
+
+	internp = Z_GMAGICKPIXEL_OBJ_P(getThis());
+
+	switch (color_quantum) {
+		case GMAGICK_COLOR_BLACK:
+			PixelSetBlackQuantum(internp->pixel_wand, color_value_quantum);
+			break;
+
+		case GMAGICK_COLOR_BLUE:
+			PixelSetBlueQuantum(internp->pixel_wand, color_value_quantum);
+			break;
+
+		case GMAGICK_COLOR_CYAN:
+			PixelSetCyanQuantum(internp->pixel_wand, color_value_quantum);
+			break;
+
+		case GMAGICK_COLOR_GREEN:
+			PixelSetGreenQuantum(internp->pixel_wand, color_value_quantum);
+			break;
+
+		case GMAGICK_COLOR_RED:
+			PixelSetRedQuantum(internp->pixel_wand, color_value_quantum);
+			break;
+
+		case GMAGICK_COLOR_YELLOW:
+			PixelSetYellowQuantum(internp->pixel_wand, color_value_quantum);
+			break;
+
+		case GMAGICK_COLOR_MAGENTA:
+			PixelSetMagentaQuantum(internp->pixel_wand, color_value_quantum);
+			break;
+
+		case GMAGICK_COLOR_OPACITY:
+			PixelSetOpacityQuantum(internp->pixel_wand, color_value_quantum);
+			break;
+
+		default:
+			sprintf(r, "Unknown color type: %d", color_quantum);
+			GMAGICK_THROW_GMAGICKPIXEL_EXCEPTION(internp->pixel_wand, r);
+			break;
+
+	}
+	GMAGICK_CHAIN_METHOD;
+}
+/* }}} */

--- a/package.xml
+++ b/package.xml
@@ -239,6 +239,7 @@ Fix for setImagePage availability detection. Added hald_8.png test image.
 				<file role="test" name="gmagickpixel-002-setcolorvalue_getcolorvalue.phpt"/>
 				<file role="test" name="gmagickpixel-003-getcolorcount.phpt"/>
 				<file role="test" name="gmagickpixel-004-clone.phpt"/>
+				<file role="test" name="gmagickpixel-005-setcolorvaluequantum_getcolorvaluequantum.phpt"/>
 				<file role="test" name="Vera.ttf"/>
 				<file role="test" name="hald_8.png"/>
 

--- a/php_gmagick.h
+++ b/php_gmagick.h
@@ -472,4 +472,6 @@ PHP_METHOD(gmagickpixel, getcolor);
 PHP_METHOD(gmagickpixel, getcolorcount);
 PHP_METHOD(gmagickpixel, getcolorvalue);
 PHP_METHOD(gmagickpixel, setcolorvalue);
+PHP_METHOD(gmagickpixel, getcolorvaluequantum);
+PHP_METHOD(gmagickpixel, setcolorvaluequantum);
 #endif

--- a/tests/gmagickpixel-005-setcolorvaluequantum_getcolorvaluequantum.phpt
+++ b/tests/gmagickpixel-005-setcolorvaluequantum_getcolorvaluequantum.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Test setColorValueQuantum and getColorValueQuantum methods
+--SKIPIF--
+<?php
+if(!extension_loaded('gmagick')) die('skip');
+?>
+--FILE--
+<?php
+$gp = new GMagickPixel();
+echo $gp->getColorValueQuantum(Gmagick::COLOR_BLACK). "\n";
+$gp->setColorValueQuantum(Gmagick::COLOR_BLACK,1);
+echo $gp->getColorValueQuantum(Gmagick::COLOR_BLACK). "\n";
+?>
+--EXPECTF--
+0
+1


### PR DESCRIPTION
Part of #30, adds new methods `getColorValueQuantum` and `setColorValueQuantum` which covers:

* PixelGetBlackQuantum
* PixelGetBlueQuantum
* PixelGetCyanQuantum
* PixelGetGreenQuantum
* PixelGetMagentaQuantum
* PixelGetOpacityQuantum
* PixelGetRedQuantum
* PixelGetYellowQuantum
* PixelSetBlackQuantum
* PixelSetBlueQuantum
* PixelSetCyanQuantum
* PixelSetGreenQuantum
* PixelSetMagentaQuantum
* PixelSetOpacityQuantum
* PixelSetRedQuantum
* PixelSetYellowQuantum
