### PR TITLE
Added cleaner hack for queryFontMetrics.

### DIFF
--- a/tests/bug71626.phpt
+++ b/tests/bug71626.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Test bug 71626 - multiple calls to queryFontMetrics
+--SKIPIF--
+<?php
+
+if(!extension_loaded('gmagick')) die('skip');
+?>
+--FILE--
+<?php
+
+$textWidth = null;
+
+for ($i=0; $i<5; $i++) {
+	$image = new Gmagick();
+	$fontDraw = new GmagickDraw();
+	$fontMetrics = $image->queryFontMetrics($fontDraw, 'g');
+
+	if (is_array($fontMetrics) === false ||
+		isset($fontMetrics['textWidth']) === false) {
+		echo "fontMetrics contains bad data".PHP_EOL;
+		var_dump($fontMetrics);
+	}
+}
+
+
+for ($i=0; $i<5; $i++) {
+	$gmagick = new \Gmagick("magick:logo");
+	$fontDraw = new GmagickDraw();
+	$fontMetrics = $image->queryFontMetrics($fontDraw, 'g');
+
+	if (is_array($fontMetrics) === false ||
+		isset($fontMetrics['textWidth']) === false) {
+		echo "fontMetrics contains bad data".PHP_EOL;
+		var_dump($fontMetrics);
+	}
+}
+
+
+echo "ok";
+?>
+--EXPECT--
+ok


### PR DESCRIPTION
There was an existing hack in queryFontMetrics to allow it to be called when the image list is empty. That hack depended on adding an image temporarily and then removing it through MagickRemoveImage.

Unfortunately adding and removing images in GraphicsMagick appears to be fundamentally broken. The code change is to use a completely separate image as a new and improved hack to allow queryFontMetrics to work on empty image lists.

https://bugs.php.net/bug.php?id=71626