### PR TITLE
References are handled differently in 7.

### DIFF
--- a/gmagick_helpers.c
+++ b/gmagick_helpers.c
@@ -437,6 +437,7 @@ void *get_pointinfo_array(zval *coordinate_array, int *num_elements TSRMLS_DC)
 	coordinates = (PointInfo *)emalloc(sizeof(PointInfo) * elements_count);
 
 	ZEND_HASH_FOREACH_VAL(coords, current) {
+		ZVAL_DEREF(current);
 		/* If its something than array lets error here */
 		if(current == NULL || Z_TYPE_P(current) != IS_ARRAY) {
 			efree(coordinates);
@@ -457,6 +458,7 @@ void *get_pointinfo_array(zval *coordinate_array, int *num_elements TSRMLS_DC)
 
 		/* Get X */
 		pz_x = zend_hash_str_find(sub_array, "x", strlen("x"));
+		ZVAL_DEREF(pz_x);
 		if(Z_TYPE_P(pz_x) != IS_DOUBLE && Z_TYPE_P(pz_x) != IS_LONG) {
 			efree(coordinates);
 			coordinates = (PointInfo *)NULL;
@@ -465,6 +467,7 @@ void *get_pointinfo_array(zval *coordinate_array, int *num_elements TSRMLS_DC)
 
 		/* Get Y */
 		pz_y = zend_hash_str_find(sub_array, "y", strlen("y"));
+		ZVAL_DEREF(pz_y);
 		if(Z_TYPE_P(pz_y) != IS_DOUBLE && Z_TYPE_P(pz_y) != IS_LONG) {
 			efree(coordinates);
 			coordinates = (PointInfo *)NULL;
@@ -540,6 +543,7 @@ double *get_double_array_from_zval(zval *param_array, long *num_elements TSRMLS_
 	double_array = (double *)emalloc(sizeof(double) * elements_count);
 
 	ZEND_HASH_FOREACH_VAL(ht, current) {
+		ZVAL_DEREF(current);
 		if(Z_TYPE_P(current) == IS_LONG) {
 			double_array[i] = (double)Z_LVAL_P(current);
 		} else if (Z_TYPE_P(current) == IS_DOUBLE) {

--- a/tests/bug_71742.phpt
+++ b/tests/bug_71742.phpt
@@ -1,0 +1,51 @@
+--TEST--
+Bug #71742 polyline touched by array_walk
+--SKIPIF--
+<?php require_once(dirname(__FILE__) . '/skipif.inc');
+--FILE--
+<?php
+
+$coordinates = [];
+
+foreach (range (0, 100) as $index) {
+	$coordinates[] = array(
+		'x' => 2 * $index,
+		'y' => pow($index, 2)
+	);
+}
+
+$callback = function (&$coordinate) {
+	$coordinate['y'] = 200 - $coordinate['y'] / 50;
+};
+
+array_walk($coordinates, $callback);
+
+$imagick = new GMagick();
+$imagick->newImage(200, 200, "white");
+
+$draw = new GmagickDraw();
+$draw->setFillColor("none");
+$draw->setStrokeColor("black");
+
+//Fatal error in PHP 7, but not in PHP <= 5.6
+$draw->polyline($coordinates);
+
+$draw->translate(0, -20);
+////Works in PHP 7
+$draw->polyline (array_values($coordinates));
+$imagick->drawImage($draw);
+//$imagick->writeImage(getcwd(). "/test.png");
+$imagick->setImageFormat('png');
+$bytes = $imagick->getImageBlob();
+
+if (strlen($bytes) <= 0) { 
+	echo "Failed to generate image.";
+}
+
+//$imagick->writeImage("./bugTest.png");
+
+echo "Ok";
+
+?>
+--EXPECT--
+Ok


### PR DESCRIPTION
This apparently is a thing.

Basically when someone passes in data where the values are references rather than normal values, the zvals need to be dereferenced before being used.

You might want to get someone who knows about this stuff to check it.