### PR TITLE
Fix has(Next|Previous)Image return type

### DIFF
--- a/gmagick_methods.c
+++ b/gmagick_methods.c
@@ -3126,7 +3126,7 @@ PHP_METHOD(gmagick, hasnextimage)
 		RETURN_FALSE;
 	}
 
-	GMAGICK_CHAIN_METHOD;
+	RETURN_TRUE;
 }
 /* }}} */
 
@@ -3150,7 +3150,7 @@ PHP_METHOD(gmagick, haspreviousimage)
 		RETURN_FALSE;
 	}
 
-	GMAGICK_CHAIN_METHOD;
+	RETURN_TRUE;
 }
 /* }}} */
 


### PR DESCRIPTION
`hasNextImage()` and `hasPreviousImage()` are documented as returning `bool`, but actually return the current `Gmagick` object on success, and `false` on failure.

This PR changes the success return type to `true`.