### PR TITLE
Remove TSRM macros for PHP 8.0 compatibility

### DIFF
--- a/gmagick.c
+++ b/gmagick.c
@@ -33,9 +33,9 @@ zend_class_entry *php_gmagick_exception_class_entry;
 zend_class_entry *php_gmagickdraw_exception_class_entry;
 zend_class_entry *php_gmagickpixel_exception_class_entry;
 
-/* {{{ static void php_gmagick_object_free_storage(void *object TSRMLS_DC)
+/* {{{ static void php_gmagick_object_free_storage(void *object)
 */
-static void php_gmagick_object_free_storage(zend_object *object TSRMLS_DC)
+static void php_gmagick_object_free_storage(zend_object *object)
 {
 	php_gmagick_object *intern = GMAGICK_FETCH_OBJECT(object);
 
@@ -47,7 +47,7 @@ static void php_gmagick_object_free_storage(zend_object *object TSRMLS_DC)
 		DestroyMagickWand(intern->magick_wand);
 	}
 
-	zend_object_std_dtor(&intern->zo TSRMLS_CC);
+	zend_object_std_dtor(&intern->zo);
 }
 /* }}} */
 
@@ -83,9 +83,9 @@ static zend_object *php_gmagick_object_new(zend_class_entry *class_type)
 }
 /* }}} */
 
-/* {{{ static zend_object *php_gmagick_clone_gmagick_object(zval *this_ptr TSRMLS_DC)
+/* {{{ static zend_object *php_gmagick_clone_gmagick_object(zval *this_ptr)
 */
-static zend_object *php_gmagick_clone_gmagick_object(zval *this_ptr TSRMLS_DC)
+static zend_object *php_gmagick_clone_gmagick_object(zval *this_ptr)
 {
 	php_gmagick_object *old_obj = Z_GMAGICK_OBJ_P(this_ptr);
 	php_gmagick_object *new_obj = GMAGICK_FETCH_OBJECT(php_gmagick_object_new_ex(old_obj->zo.ce, 0));
@@ -150,7 +150,7 @@ static zend_object *php_gmagickdraw_object_new(zend_class_entry *class_type)
 }
 /* }}} */
 
-/* {{{ static void php_gmagickpixel_object_free_storage(zend_object *object TSRMLS_DC)
+/* {{{ static void php_gmagickpixel_object_free_storage(zend_object *object)
 */
 static void php_gmagickpixel_object_free_storage(zend_object *object)
 {
@@ -184,7 +184,7 @@ static zend_object *php_gmagickpixel_object_new_ex(zend_class_entry *class_type,
 
 	/* ALLOC_HASHTABLE(intern->zo.properties); */
 
-	zend_object_std_init(&intern->zo, class_type TSRMLS_CC);
+	zend_object_std_init(&intern->zo, class_type);
 	object_properties_init(&intern->zo, class_type );
 
 	intern->zo.handlers = &gmagickpixel_object_handlers;
@@ -195,7 +195,7 @@ static zend_object *php_gmagickpixel_object_new_ex(zend_class_entry *class_type,
 
 /* {{{ static zend_object *php_gmagickpixel_object_new(zend_class_entry *class_type)
 */
-static zend_object *php_gmagickpixel_object_new(zend_class_entry *class_type TSRMLS_DC)
+static zend_object *php_gmagickpixel_object_new(zend_class_entry *class_type)
 {
 	return php_gmagickpixel_object_new_ex(class_type, 1);
 }

--- a/gmagick_helpers.c
+++ b/gmagick_helpers.c
@@ -26,7 +26,6 @@
 */
 void php_gmagick_initialize_constants()
 {
-	TSRMLS_FETCH();
 
 	/* Constants defined in php_gmagick.h */
 	GMAGICK_REGISTER_CONST_LONG("COLOR_BLACK", GMAGICK_COLOR_BLACK);
@@ -410,9 +409,9 @@ void php_gmagick_initialize_constants()
 }
 /* }}} */
 
-/* {{{ void *get_pointinfo_array(zval *coordinate_array, int *num_elements TSRMLS_DC)
+/* {{{ void *get_pointinfo_array(zval *coordinate_array, int *num_elements)
 */
-void *get_pointinfo_array(zval *coordinate_array, int *num_elements TSRMLS_DC)
+void *get_pointinfo_array(zval *coordinate_array, int *num_elements)
 {
 	PointInfo *coordinates;
 	long elements_count, sub_elements_count, i;
@@ -493,9 +492,9 @@ void *get_pointinfo_array(zval *coordinate_array, int *num_elements TSRMLS_DC)
 }
 /* }}} */
 
-/* {{{ check_configured_font(char *font, int font_len TSRMLS_DC)
+/* {{{ check_configured_font(char *font, int font_len)
 */
-int check_configured_font(char *font, int font_len TSRMLS_DC)
+int check_configured_font(char *font, int font_len)
 {
 	int retval = 0;
 	char **fonts;
@@ -517,9 +516,9 @@ int check_configured_font(char *font, int font_len TSRMLS_DC)
 }
 /* }}} */
 
-/* {{{ get_double_array_from_zval(zval *param_array, long *num_elements TSRMLS_DC)
+/* {{{ get_double_array_from_zval(zval *param_array, long *num_elements)
 */
-double *get_double_array_from_zval(zval *param_array, long *num_elements TSRMLS_DC)
+double *get_double_array_from_zval(zval *param_array, long *num_elements)
 {
 	zval *current;
 	HashTable *ht;
@@ -558,9 +557,9 @@ double *get_double_array_from_zval(zval *param_array, long *num_elements TSRMLS_
 	return double_array;
 }
 
-/* {{{ count_occurences_of(char needle, char *haystack TSRMLS_DC)
+/* {{{ count_occurences_of(char needle, char *haystack)
 */
-int count_occurences_of(char needle, char *haystack TSRMLS_DC)
+int count_occurences_of(char needle, char *haystack)
 {
 	int occurances = 0;
 
@@ -629,9 +628,9 @@ void s_calculate_crop(
 }
 
 
-/* {{{ zend_bool crop_thumbnail_image(MagickWand *magick_wand, long desired_width, long desired_height TSRMLS_DC)
+/* {{{ zend_bool crop_thumbnail_image(MagickWand *magick_wand, long desired_width, long desired_height)
 */
-zend_bool crop_thumbnail_image(MagickWand *magick_wand, long desired_width, long desired_height, zend_bool legacy TSRMLS_DC)
+zend_bool crop_thumbnail_image(MagickWand *magick_wand, long desired_width, long desired_height, zend_bool legacy)
 {
 	long offset_x = 0, offset_y = 0, new_width, new_height;
 
@@ -758,16 +757,15 @@ zend_bool php_gmagick_thumbnail_dimensions(MagickWand *magick_wand, zend_bool be
 zend_bool php_gmagick_ensure_not_empty(MagickWand *magick_wand)
 {
 	if (MagickGetNumberImages(magick_wand) == 0) {
-	    TSRMLS_FETCH ();
 			GMAGICK_THROW_GMAGICK_EXCEPTION_EX(magick_wand, "Can not process empty Gmagick object");   
 	    return 0;
 	}
 	return 1;
 }
 
-/** double *php_gmagick_zval_to_double_array(zval *param_array, long *num_elements TSRMLS_DC)
+/** double *php_gmagick_zval_to_double_array(zval *param_array, long *num_elements)
 */
-double *php_gmagick_zval_to_double_array(zval *param_array, long *num_elements TSRMLS_DC)
+double *php_gmagick_zval_to_double_array(zval *param_array, long *num_elements)
 {
 	zval *current;
 	HashTable *ht;
@@ -795,7 +793,7 @@ double *php_gmagick_zval_to_double_array(zval *param_array, long *num_elements T
 }
 
 
-zend_bool php_gmagick_stream_handler(php_gmagick_object *intern, php_stream *stream, GmagickOperationType type TSRMLS_DC)
+zend_bool php_gmagick_stream_handler(php_gmagick_object *intern, php_stream *stream, GmagickOperationType type)
 {
 	FILE *fp;
 	unsigned int status;

--- a/gmagick_methods.c
+++ b/gmagick_methods.c
@@ -42,7 +42,7 @@ static MagickBool OpenBaseDirMonitor(const ConfirmAccessMode mode,
 					ExceptionInfo *exception)
 {
 	ARG_NOT_USED(exception);
-	if (php_check_open_basedir_ex(path, 0 TSRMLS_CC)) {
+	if (php_check_open_basedir_ex(path, 0)) {
 		return MagickFail;
 	}
 	return MagickPass;
@@ -84,7 +84,7 @@ PHP_METHOD(gmagick, __construct)
 	char *filename = NULL;
 	size_t filename_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s!", &filename, &filename_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s!", &filename, &filename_len) == FAILURE) {
 		return;
 	}
 	if (!filename) {
@@ -118,7 +118,7 @@ PHP_METHOD(gmagick, annotateimage)
 	size_t text_len;
 	zval *objvar;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Oddds", &objvar, php_gmagickdraw_sc_entry, &x, &y, &angle, &text, &text_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Oddds", &objvar, php_gmagickdraw_sc_entry, &x, &y, &angle, &text, &text_len) == FAILURE) {
 		return;
 	}
 
@@ -147,7 +147,7 @@ PHP_METHOD(gmagick, blurimage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &radius, &sigma) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &radius, &sigma) == FAILURE) {
 		return;
 	}
 
@@ -176,7 +176,7 @@ PHP_METHOD(gmagick, writeimage)
 	size_t filename_len;
 	zend_bool all_frames = 0;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|b", &filename, &filename_len, &all_frames) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|b", &filename, &filename_len, &all_frames) == FAILURE) {
 		return;
 	}
 	
@@ -222,7 +222,7 @@ PHP_METHOD(gmagick, thumbnailimage)
 	zend_bool fit = 0;
 	zend_bool legacy = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll|bb", &columns, &rows, &fit, &legacy) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ll|bb", &columns, &rows, &fit, &legacy) == FAILURE) {
 		return;
 	}
 
@@ -257,7 +257,7 @@ PHP_METHOD(gmagick, resizeimage)
 	zend_bool fit = 0;
 	zend_bool legacy = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "llld|bb", &width, &height, &filter, &blur, &fit, &legacy) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "llld|bb", &width, &height, &filter, &blur, &fit, &legacy) == FAILURE) {
 		return;
 	}
 
@@ -286,7 +286,7 @@ PHP_METHOD(gmagick, clear)
 	int i, image_count;
 	zend_bool failure = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -315,7 +315,7 @@ PHP_METHOD(gmagick, cropimage)
 	php_gmagick_object *intern;
 	long x, y, width, height;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "llll", &width, &height, &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "llll", &width, &height, &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -341,14 +341,14 @@ PHP_METHOD(gmagick, cropthumbnailimage)
 	php_gmagick_object *intern;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll|b", &crop_width, &crop_height, &legacy) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ll|b", &crop_width, &crop_height, &legacy) == FAILURE) {
 		return;
 	}
 
 	intern = Z_GMAGICK_OBJ_P(getThis());
 	GMAGICK_CHECK_NOT_EMPTY(intern->magick_wand, 1, 1);
 
-	if (!crop_thumbnail_image(intern->magick_wand, crop_width, crop_height, legacy TSRMLS_CC)) {
+	if (!crop_thumbnail_image(intern->magick_wand, crop_width, crop_height, legacy)) {
 		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to crop-thumbnail image");
 	}
 
@@ -367,7 +367,7 @@ PHP_METHOD(gmagick, coalesceimages)
 	MagickWand *tmp_wand;
 	php_gmagick_object *intern, *intern_return;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -397,7 +397,7 @@ PHP_METHOD(gmagick, compositeimage)
 	php_gmagick_object *source, *intern;
 	zend_long x, y, compose;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Olll", &source_obj, php_gmagick_sc_entry, &compose, &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Olll", &source_obj, php_gmagick_sc_entry, &compose, &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -429,7 +429,7 @@ PHP_METHOD(gmagick, drawimage)
 	MagickBool status;
 	php_gmagickdraw_object *internd;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O", &objvar, php_gmagickdraw_sc_entry) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &objvar, php_gmagickdraw_sc_entry) == FAILURE) {
 		return;
 	}
 	
@@ -460,7 +460,7 @@ PHP_METHOD(gmagick, addimage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O", &add_obj, php_gmagick_sc_entry) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &add_obj, php_gmagick_sc_entry) == FAILURE) {
 		return;
 	}
 
@@ -488,7 +488,7 @@ PHP_METHOD(gmagick, addnoiseimage)
 	MagickBool status;
 	zend_long noise;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &noise) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &noise) == FAILURE) {
 		return;
 	}
 
@@ -517,7 +517,7 @@ PHP_METHOD(gmagick, borderimage)
 	MagickBool status;
 	zend_long width, height;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zll", &param, &width, &height) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zll", &param, &width, &height) == FAILURE) {
 		return;
 	}
 
@@ -547,7 +547,7 @@ PHP_METHOD(gmagick, thresholdimage)
 	MagickBool status;
 	zend_long channel = DefaultChannels;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d|l", &threshold, &channel) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d|l", &threshold, &channel) == FAILURE) {
 		return;
 	}
 
@@ -577,7 +577,7 @@ PHP_METHOD(gmagick, charcoalimage)
 	php_gmagick_object *intern;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &radius, &sigma) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &radius, &sigma) == FAILURE) {
 		return;
 	}
 
@@ -604,7 +604,7 @@ PHP_METHOD(gmagick, chopimage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "llll", &width, &height, &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "llll", &width, &height, &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -634,7 +634,7 @@ PHP_METHOD(gmagick, commentimage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &comment, &comment_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &comment, &comment_len) == FAILURE) {
 		return;
 	}
 
@@ -672,7 +672,7 @@ PHP_METHOD(gmagick, cyclecolormapimage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &displace) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &displace) == FAILURE) {
 		return;
 	}
 
@@ -698,7 +698,7 @@ PHP_METHOD(gmagick, deconstructimages)
 	MagickWand *tmp_wand;
 	php_gmagick_object *intern, *intern_return;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -727,7 +727,7 @@ PHP_METHOD(gmagick, despeckleimage)
 	php_gmagick_object *intern;
 	MagickBool status;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -752,7 +752,7 @@ PHP_METHOD(gmagick, destroy)
 {
 	php_gmagick_object *intern;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -777,7 +777,7 @@ PHP_METHOD(gmagick, edgeimage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &radius) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &radius) == FAILURE) {
 		return;
 	}
 
@@ -806,7 +806,7 @@ PHP_METHOD(gmagick, embossimage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &radius, &sigma) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &radius, &sigma) == FAILURE) {
 		return;
 	}
 
@@ -835,7 +835,7 @@ PHP_METHOD(gmagick, enhanceimage)
 	php_gmagick_object *intern;
 	MagickBool status;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -861,7 +861,7 @@ PHP_METHOD(gmagick, equalizeimage)
 	php_gmagick_object *intern;
 	MagickBool status;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -887,7 +887,7 @@ PHP_METHOD(gmagick, flipimage)
 	php_gmagick_object *intern;
 	MagickBool status;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -912,7 +912,7 @@ PHP_METHOD(gmagick, flopimage)
 	php_gmagick_object *intern;
 	MagickBool status;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -941,7 +941,7 @@ PHP_METHOD(gmagick, frameimage)
 	MagickBool status;
 	zend_long width, height, inner_bevel, outer_bevel;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zllll", &param, &width, &height, &inner_bevel, &outer_bevel) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zllll", &param, &width, &height, &inner_bevel, &outer_bevel) == FAILURE) {
 		return;
 	}
 
@@ -969,7 +969,7 @@ PHP_METHOD(gmagick, gammaimage)
 	MagickBool status;
 	double gamma;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &gamma) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &gamma) == FAILURE) {
 		return;
 	}
 
@@ -996,7 +996,7 @@ PHP_METHOD(gmagick, getcopyright)
 {
 	char *copyright;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -1016,7 +1016,7 @@ PHP_METHOD(gmagick, getfilename)
 	php_gmagick_object *intern;
 	char *filename;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -1041,7 +1041,7 @@ PHP_METHOD(gmagick, getimagebackgroundcolor)
 	MagickBool status;	
 	PixelWand *tmp_wand;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -1076,7 +1076,7 @@ PHP_METHOD(gmagick, getimageblob)
 	size_t image_size;
 	char *buffer;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -1109,7 +1109,7 @@ PHP_METHOD(gmagick, getimagesblob)
 	size_t current;
 	MagickBool status;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 	
@@ -1155,7 +1155,7 @@ PHP_METHOD(gmagick, setimagebackgroundcolor)
 	php_gmagickpixel_object *internp;
 	MagickBool status;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &param) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &param) == FAILURE) {
 		return;
 	}
 
@@ -1184,7 +1184,7 @@ PHP_METHOD(gmagick, getimageblueprimary)
 	MagickBool status;
 	double x, y;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -1215,7 +1215,7 @@ PHP_METHOD(gmagick, getimagebordercolor)
 	MagickBool status;
 	PixelWand *tmp_wand;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -1250,7 +1250,7 @@ PHP_METHOD(gmagick, getimagechanneldepth)
 	zend_long channel_type, channel_depth;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &channel_type) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &channel_type) == FAILURE) {
 		return;
 	}
 
@@ -1272,7 +1272,7 @@ PHP_METHOD(gmagick, setimageblueprimary)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -1299,7 +1299,7 @@ PHP_METHOD(gmagick, setimagebordercolor)
 	php_gmagickpixel_object *internp;
 	MagickBool status;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &param) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &param) == FAILURE) {
 		return;
 	}
 
@@ -1328,7 +1328,7 @@ PHP_METHOD(gmagick, setimagechanneldepth)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll", &channel_type, &depth) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ll", &channel_type, &depth) == FAILURE) {
 		return;
 	}
 
@@ -1355,7 +1355,7 @@ PHP_METHOD(gmagick, setimagecolorspace)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &colorspace) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &colorspace) == FAILURE) {
 		return;
 	}
 
@@ -1382,7 +1382,7 @@ PHP_METHOD(gmagick, setinterlacescheme)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &schema) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &schema) == FAILURE) {
 		return;
 	}
 
@@ -1405,7 +1405,7 @@ PHP_METHOD(gmagick, getimagecolorspace)
 	php_gmagick_object *intern;
 	long colorSpace;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -1424,7 +1424,7 @@ PHP_METHOD(gmagick, getimagecolors)
 {
 	php_gmagick_object *intern;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -1444,7 +1444,7 @@ PHP_METHOD(gmagick, getimagecompose)
 	php_gmagick_object *intern;
 	long composite;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -1464,7 +1464,7 @@ PHP_METHOD(gmagick, getimagedelay)
 	php_gmagick_object *intern;
 	long delay;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -1484,7 +1484,7 @@ PHP_METHOD(gmagick, getimagedepth)
 	php_gmagick_object *intern;
 	long depth;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -1504,7 +1504,7 @@ PHP_METHOD(gmagick, getnumberimages)
 	php_gmagick_object *intern;
 	unsigned long num_images;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 	
@@ -1525,7 +1525,7 @@ PHP_METHOD(gmagick, setimagecompose)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &compose) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &compose) == FAILURE) {
 		return;
 	}
 
@@ -1552,7 +1552,7 @@ PHP_METHOD(gmagick, setimagecompression)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &compression) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &compression) == FAILURE) {
 		return;
 	}
 
@@ -1599,7 +1599,7 @@ PHP_METHOD(gmagick, setimagedelay)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &delay) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &delay) == FAILURE) {
 		return;
 	}
 
@@ -1626,7 +1626,7 @@ PHP_METHOD(gmagick, setimagedepth)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &depth) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &depth) == FAILURE) {
 		return;
 	}
 
@@ -1651,7 +1651,7 @@ PHP_METHOD(gmagick, getimagedispose)
 	php_gmagick_object *intern;
 	long dispose;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 	
@@ -1673,7 +1673,7 @@ PHP_METHOD(gmagick, setimagedispose)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &dispose) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &dispose) == FAILURE) {
 		return;
 	}
 
@@ -1701,7 +1701,7 @@ PHP_METHOD(gmagick, setfilename)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &filename, &filename_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &filename, &filename_len) == FAILURE) {
 		return;
 	}
 
@@ -1725,7 +1725,7 @@ PHP_METHOD(gmagick, getimage)
 	MagickWand *tmp_wand;
 	php_gmagick_object *intern, *intern_return;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 	
@@ -1756,7 +1756,7 @@ PHP_METHOD(gmagick, setimage)
 	php_gmagick_object *intern, *replace;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O", &objvar, php_gmagick_sc_entry) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &objvar, php_gmagick_sc_entry) == FAILURE) {
 		return;
 	}
 
@@ -1786,7 +1786,7 @@ PHP_METHOD(gmagick, getimageextrema)
 	unsigned long min, max;
 	MagickBool status;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -1816,7 +1816,7 @@ PHP_METHOD(gmagick, getimagefilename)
 	php_gmagick_object *intern;
 	char *filename;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -1846,7 +1846,7 @@ PHP_METHOD(gmagick, setimagefilename)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &filename, &filename_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &filename, &filename_len) == FAILURE) {
 		return;
 	}
 
@@ -1872,7 +1872,7 @@ PHP_METHOD(gmagick, getimageformat)
 	php_gmagick_object *intern;
 	char *format;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -1902,7 +1902,7 @@ PHP_METHOD(gmagick, setimageformat)
 	php_gmagick_object *intern;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &format, &format_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &format, &format_len) == FAILURE) {
 		return;
 	}
 
@@ -1931,7 +1931,7 @@ PHP_METHOD(gmagick, setcompressionquality)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &compression_quality) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &compression_quality) == FAILURE) {
 		return;
 	}
 
@@ -1957,7 +1957,7 @@ PHP_METHOD(gmagick, getimagegamma)
 	php_gmagick_object *intern;
 	double gamma;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -1979,7 +1979,7 @@ PHP_METHOD(gmagick, setimagegamma)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &gamma) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &gamma) == FAILURE) {
 		return;
 	}
 
@@ -2005,7 +2005,7 @@ PHP_METHOD(gmagick, getimagegreenprimary)
 	double x, y;
 	MagickBool status;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2036,7 +2036,7 @@ PHP_METHOD(gmagick, setimagegreenprimary)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -2062,7 +2062,7 @@ PHP_METHOD(gmagick, getimageheight)
 	php_gmagick_object *intern;
 	long height;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2086,7 +2086,7 @@ PHP_METHOD(gmagick, getimagehistogram)
 	unsigned long i;
 	zval tmp_pixelwand;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2116,7 +2116,7 @@ PHP_METHOD(gmagick, getimageindex)
 	MagickBool status;
 	php_gmagick_object *intern;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2138,7 +2138,7 @@ PHP_METHOD(gmagick, setimageindex)
 	php_gmagick_object *intern;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &index) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &index) == FAILURE) {
 		return;
 	}
 
@@ -2164,7 +2164,7 @@ PHP_METHOD(gmagick, getimageinterlacescheme)
 	php_gmagick_object *intern;
 	long interlace;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2186,7 +2186,7 @@ PHP_METHOD(gmagick, setimageinterlacescheme)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &interlace) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &interlace) == FAILURE) {
 		return;
 	}
 
@@ -2212,7 +2212,7 @@ PHP_METHOD(gmagick, getimageiterations)
 	php_gmagick_object *intern;
 	long iterations;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2232,7 +2232,7 @@ PHP_METHOD(gmagick, getimagegeometry)
 	long width,height;
 	php_gmagick_object *intern;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 	
@@ -2261,7 +2261,7 @@ PHP_METHOD(gmagick, getimagemattecolor)
 	MagickBool status;
 	PixelWand *tmp_wand;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2297,7 +2297,7 @@ PHP_METHOD(gmagick, getimagematte)
 	php_gmagick_object *intern;
 	long matte;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2360,7 +2360,7 @@ PHP_METHOD(gmagick, getimageprofile)
 
 	unsigned long length;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &name, &name_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &name, &name_len) == FAILURE) {
 		return;
 	}
 
@@ -2388,7 +2388,7 @@ PHP_METHOD(gmagick, getimageredprimary)
 	MagickBool status;
 	double x, y;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2417,7 +2417,7 @@ PHP_METHOD(gmagick, getimagerenderingintent)
 	php_gmagick_object *intern;
 	long renderingIntent;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2439,7 +2439,7 @@ PHP_METHOD(gmagick, getimageresolution)
 	MagickBool status;
 	double x, y;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2468,7 +2468,7 @@ PHP_METHOD(gmagick, getimagescene)
 	php_gmagick_object *intern;
 	unsigned long scene;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2488,7 +2488,7 @@ PHP_METHOD(gmagick, getimagesignature)
 	php_gmagick_object *intern;
 	char *signature;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2510,7 +2510,7 @@ PHP_METHOD(gmagick, getimagetype)
 	php_gmagick_object *intern;
 	long imageType;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2532,7 +2532,7 @@ PHP_METHOD(gmagick, setimageiterations)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &iterations) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &iterations) == FAILURE) {
 		return;
 	}
 
@@ -2561,7 +2561,7 @@ PHP_METHOD(gmagick, setimageprofile)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss", &name, &name_len, &profile, &profile_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss", &name, &name_len, &profile, &profile_len) == FAILURE) {
 		return;
 	}
 
@@ -2588,7 +2588,7 @@ PHP_METHOD(gmagick, setimageredprimary)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -2615,7 +2615,7 @@ PHP_METHOD(gmagick, setimagerenderingintent)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &rendering_intent) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &rendering_intent) == FAILURE) {
 		return;
 	}
 
@@ -2642,7 +2642,7 @@ PHP_METHOD(gmagick, setimageresolution)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &x_res, &y_res) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &x_res, &y_res) == FAILURE) {
 		return;
 	}
 
@@ -2669,7 +2669,7 @@ PHP_METHOD(gmagick, setimagescene)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &scene) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &scene) == FAILURE) {
 		return;
 	}
 
@@ -2696,7 +2696,7 @@ PHP_METHOD(gmagick, setimagetype)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &image_type) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &image_type) == FAILURE) {
 		return;
 	}
 
@@ -2725,7 +2725,7 @@ PHP_METHOD(gmagick, setimagepage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "llll", &width, &height, &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "llll", &width, &height, &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -2751,7 +2751,7 @@ PHP_METHOD(gmagick, getimageunits)
 	php_gmagick_object *intern;
 	long resolutionType;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2772,7 +2772,7 @@ PHP_METHOD(gmagick, getimagewhitepoint)
 	MagickBool status;
 	double x, y;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2801,7 +2801,7 @@ PHP_METHOD(gmagick, getimagewidth)
 	php_gmagick_object *intern;
 	unsigned long width;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2820,7 +2820,7 @@ PHP_METHOD(gmagick, getpackagename)
 {
 	char *package_name;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2840,7 +2840,7 @@ PHP_METHOD(gmagick, getquantumdepth)
 	char *quantum_depth;
 	unsigned long depth;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2861,7 +2861,7 @@ PHP_METHOD(gmagick, getreleasedate)
 {
 	char *release_date;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2880,7 +2880,7 @@ PHP_METHOD(gmagick, getresourcelimit)
 {
 	zend_long resource_type;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &resource_type) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &resource_type) == FAILURE) {
 		return;
 	}
 
@@ -2897,7 +2897,7 @@ PHP_METHOD(gmagick, getsamplingfactors)
 	double *sampling_factors;
 	unsigned long number_factors = 0, i;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2924,7 +2924,7 @@ PHP_METHOD(gmagick, getsize)
 	unsigned long columns, rows;
 	MagickBool status;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -2953,7 +2953,7 @@ PHP_METHOD(gmagick, setimageunits)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &units) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &units) == FAILURE) {
 		return;
 	}
 
@@ -2983,7 +2983,7 @@ PHP_METHOD(gmagick, setimagewhitepoint)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -3012,11 +3012,11 @@ PHP_METHOD(gmagick, setsamplingfactors)
 	long elements = 0;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &factors) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "a", &factors) == FAILURE) {
 		return;
 	}
 
-	double_array = get_double_array_from_zval(factors, &elements TSRMLS_CC);
+	double_array = get_double_array_from_zval(factors, &elements);
 
 	if (double_array == (double *)NULL) {
 		GMAGICK_THROW_EXCEPTION_WITH_MESSAGE(GMAGICK_CLASS, "Can't read array", 1);
@@ -3044,7 +3044,7 @@ PHP_METHOD(gmagick, setresourcelimit)
 	zend_long type, limit;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll", &type, &limit) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ll", &type, &limit) == FAILURE) {
 		return;
 	}
 	
@@ -3068,7 +3068,7 @@ PHP_METHOD(gmagick, setsize)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll", &columns, &rows) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ll", &columns, &rows) == FAILURE) {
 		return;
 	}
 
@@ -3091,7 +3091,7 @@ PHP_METHOD(gmagick, getversion)
 	char *version_string;
 	unsigned long version_number;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -3114,7 +3114,7 @@ PHP_METHOD(gmagick, hasnextimage)
 	php_gmagick_object *intern;
 	MagickBool status;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -3138,7 +3138,7 @@ PHP_METHOD(gmagick, haspreviousimage)
 	php_gmagick_object *intern;
 	MagickBool status;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -3164,7 +3164,7 @@ PHP_METHOD(gmagick, implodeimage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &radius) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &radius) == FAILURE) {
 		return;
 	}
 
@@ -3192,7 +3192,7 @@ PHP_METHOD(gmagick, labelimage)
 	php_gmagick_object *intern;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &label, &label_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &label, &label_len) == FAILURE) {
 		return;
 	}
 
@@ -3221,7 +3221,7 @@ PHP_METHOD(gmagick, levelimage)
 	zend_long channel = DefaultChannels;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ddd|l", &black_point, &gamma, &white_point, &channel) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ddd|l", &black_point, &gamma, &white_point, &channel) == FAILURE) {
 		return;
 	}
 
@@ -3251,7 +3251,7 @@ PHP_METHOD(gmagick, magnifyimage)
 	php_gmagick_object *intern;
 	MagickBool status;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -3279,7 +3279,7 @@ PHP_METHOD(gmagick, mapimage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Ob", &map_obj, php_gmagick_sc_entry, &dither) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Ob", &map_obj, php_gmagick_sc_entry, &dither) == FAILURE) {
 		return;
 	}
 
@@ -3307,7 +3307,7 @@ PHP_METHOD(gmagick, medianfilterimage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &radius) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &radius) == FAILURE) {
 		return;
 	}
 
@@ -3335,7 +3335,7 @@ PHP_METHOD(gmagick, negateimage)
 	zend_long channel = DefaultChannels;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "b|l", &gray, &channel) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "b|l", &gray, &channel) == FAILURE) {
 		return;
 	}
 
@@ -3360,7 +3360,7 @@ PHP_METHOD(gmagick, minifyimage)
 	php_gmagick_object *intern;
 	MagickBool status;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -3388,7 +3388,7 @@ PHP_METHOD(gmagick, modulateimage)
 	MagickBool status;
 	double brightness, saturation, hue;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ddd", &brightness, &saturation, &hue) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ddd", &brightness, &saturation, &hue) == FAILURE) {
 		return;
 	}
 
@@ -3414,7 +3414,7 @@ PHP_METHOD(gmagick, motionblurimage)
 	MagickBool status;
 	double radius, sigma, angle;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ddd", &radius, &sigma, &angle) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ddd", &radius, &sigma, &angle) == FAILURE) {
 		return;
 	}
 
@@ -3442,7 +3442,7 @@ PHP_METHOD(gmagick, nextimage)
 	php_gmagick_object *intern;
 	MagickBool status;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -3473,7 +3473,7 @@ PHP_METHOD(gmagick, newimage)
 	char xc_str[MAX_BUFFER_SIZE];
 
  	/* Parse parameters given to function */
- 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "lls|s", &columns, &rows, &param, &param_len, &format, &format_len) == FAILURE) {
+ 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "lls|s", &columns, &rows, &param, &param_len, &format, &format_len) == FAILURE) {
  		return;
 	}
  	intern = Z_GMAGICK_OBJ_P(getThis());
@@ -3509,7 +3509,7 @@ PHP_METHOD(gmagick, normalizeimage)
 	zend_long channel;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|l", &channel) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &channel) == FAILURE) {
 		return;
 	}
 
@@ -3536,7 +3536,7 @@ PHP_METHOD(gmagick, oilpaintimage)
 	php_gmagick_object *intern;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &radius) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &radius) == FAILURE) {
 		return;
 	}
 
@@ -3562,7 +3562,7 @@ PHP_METHOD(gmagick, previousimage)
 	php_gmagick_object *intern;
 	MagickBool status;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -3590,7 +3590,7 @@ PHP_METHOD(gmagick, profileimage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss", &name, &name_len, &profile, &profile_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss", &name, &name_len, &profile, &profile_len) == FAILURE) {
 		return;
 	}
 
@@ -3619,7 +3619,7 @@ PHP_METHOD(gmagick, quantizeimage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "lllbb", &number_colors, &colorspace, &tree_depth, &dither, &measure_error) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "lllbb", &number_colors, &colorspace, &tree_depth, &dither, &measure_error) == FAILURE) {
 		return;
 	}
 
@@ -3649,7 +3649,7 @@ PHP_METHOD(gmagick, quantizeimages)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "lllbb", &number_colors, &colorspace, &tree_depth, &dither, &measure_error) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "lllbb", &number_colors, &colorspace, &tree_depth, &dither, &measure_error) == FAILURE) {
 		return;
 	}
 
@@ -3680,7 +3680,7 @@ PHP_METHOD(gmagick, queryfontmetrics)
 	MagickWand *temp_wand = NULL;
 	MagickWand *font_image_wand = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Os", &objvar, php_gmagickdraw_sc_entry, &text, &text_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Os", &objvar, php_gmagickdraw_sc_entry, &text, &text_len) == FAILURE) {
 		return;
 	}
 	intern = Z_GMAGICK_OBJ_P(getThis());
@@ -3726,7 +3726,7 @@ PHP_METHOD(gmagick, queryfonts)
 	char *pattern = "*";
 	size_t pattern_len = 1;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s", &pattern, &pattern_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s", &pattern, &pattern_len) == FAILURE) {
 		return;
 	}
 
@@ -3753,7 +3753,7 @@ PHP_METHOD(gmagick, queryformats)
 	char *pattern = "*";
 	size_t pattern_len = 1;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s", &pattern, &pattern_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s", &pattern, &pattern_len) == FAILURE) {
 		return;
 	}
 
@@ -3780,7 +3780,7 @@ PHP_METHOD(gmagick, radialblurimage)
 	double angle;
 	zend_long channel = DefaultChannels;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d|l", &angle, &channel) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d|l", &angle, &channel) == FAILURE) {
 		return;
 	}
 
@@ -3811,7 +3811,7 @@ PHP_METHOD(gmagick, raiseimage)
 	zend_long width, height, x, y;
 	zend_bool raise;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "llllb", &width, &height, &x, &y, &raise) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "llllb", &width, &height, &x, &y, &raise) == FAILURE) {
 		return;
 	}
 
@@ -3842,7 +3842,7 @@ PHP_METHOD(gmagick, readimageblob)
 	php_gmagick_object *intern;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|s!", &image_string, &image_string_len, &filename, &filename_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|s!", &image_string, &image_string_len, &filename, &filename_len) == FAILURE) {
 		return;
 	}
 
@@ -3880,7 +3880,7 @@ PHP_METHOD(gmagick, readimagefile)
 	zval *zstream;
 	php_stream *stream = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r|s!", &zstream, &filename, &filename_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r|s!", &zstream, &filename, &filename_len) == FAILURE) {
 		return;
 	}
 
@@ -3917,7 +3917,7 @@ PHP_METHOD(gmagick, reducenoiseimage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &radius) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &radius) == FAILURE) {
 		return;
 	}
 
@@ -3968,7 +3968,7 @@ PHP_METHOD(gmagick, removeimageprofile)
 	unsigned long profile_len;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &name, &name_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &name, &name_len) == FAILURE) {
 		return;
 	}
 
@@ -3997,7 +3997,7 @@ PHP_METHOD(gmagick, resampleimage)
 	php_gmagick_object *intern;
 	MagickBool status;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ddld", &xRes, &yRes, &filter, &blur) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ddld", &xRes, &yRes, &filter, &blur) == FAILURE) {
 		return;
 	}
 
@@ -4023,7 +4023,7 @@ PHP_METHOD(gmagick, rollimage)
 	php_gmagick_object *intern;
 	MagickBool status;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll", &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ll", &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -4051,7 +4051,7 @@ PHP_METHOD(gmagick, rotateimage)
 	double degrees;
 	MagickBool status;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zd", &param, &degrees) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zd", &param, &degrees) == FAILURE) {
 		return;
 	}
 
@@ -4086,7 +4086,7 @@ PHP_METHOD(gmagick, scaleimage)
 	zend_bool legacy = 0;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll|bb", &x, &y, &fit, &legacy) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ll|bb", &x, &y, &fit, &legacy) == FAILURE) {
 		return;
 	}
 
@@ -4119,7 +4119,7 @@ PHP_METHOD(gmagick, separateimagechannel)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &channel) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &channel) == FAILURE) {
 		return;
 	}
 
@@ -4146,7 +4146,7 @@ PHP_METHOD(gmagick, sharpenimage)
 	php_gmagick_object *intern;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &radius, &sigma) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &radius, &sigma) == FAILURE) {
 		return;
 	}
 	
@@ -4174,7 +4174,7 @@ PHP_METHOD(gmagick, shearimage)
 	double x_shear, y_shear;
 	MagickBool status;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zdd", &param, &x_shear, &y_shear) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zdd", &param, &x_shear, &y_shear) == FAILURE) {
 		return;
 	}
 
@@ -4203,7 +4203,7 @@ PHP_METHOD(gmagick, solarizeimage)
 	MagickBool status;
 	zend_long threshold;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &threshold) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &threshold) == FAILURE) {
 		return;
 	}
 
@@ -4232,7 +4232,7 @@ PHP_METHOD(gmagick, spreadimage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &radius) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &radius) == FAILURE) {
 		return;
 	}
 
@@ -4258,7 +4258,7 @@ PHP_METHOD(gmagick, stripimage)
 	php_gmagick_object *intern;
 	MagickBool status;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -4286,7 +4286,7 @@ PHP_METHOD(gmagick, swirlimage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &degrees) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &degrees) == FAILURE) {
 		return;
 	}
 
@@ -4314,7 +4314,7 @@ PHP_METHOD(gmagick, textureimage)
 	php_gmagick_object *intern, *intern_second, *intern_return;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O", &magick_object, php_gmagick_sc_entry) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &magick_object, php_gmagick_sc_entry) == FAILURE) {
 		return;
 	}
 
@@ -4348,7 +4348,7 @@ PHP_METHOD(gmagick, trimimage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &fuzz) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &fuzz) == FAILURE) {
 		return;
 	}
 
@@ -4376,7 +4376,7 @@ PHP_METHOD(gmagick, __tostring)
 	char *buffer;
 	size_t image_size;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -4412,7 +4412,7 @@ PHP_METHOD(gmagick, flattenimages)
 	php_gmagick_object *intern, *intern_return;
 	MagickWand *tmp_wand;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 	
@@ -4450,7 +4450,7 @@ PHP_METHOD(gmagick, sampleimage)
 	zend_bool legacy = 0;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll|bb", &x, &y, &fit, &legacy) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ll|bb", &x, &y, &fit, &legacy) == FAILURE) {
 		return;
 	}
 
@@ -4481,7 +4481,7 @@ PHP_METHOD(gmagick, cloneimage)
 	MagickWand *tmp_wand;
 	php_gmagick_object *intern, *intern_return;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 	
@@ -4511,7 +4511,7 @@ PHP_METHOD(gmagick, appendimages)
 	zend_bool stack = 0;
 	php_gmagick_object *intern, *intern_return;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 	
@@ -4542,7 +4542,7 @@ PHP_METHOD(gmagick, unsharpmaskimage)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dddd", &radius, &sigma, &amount, &threshold) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dddd", &radius, &sigma, &amount, &threshold) == FAILURE) {
 		return;
 	}
 
@@ -4570,7 +4570,7 @@ PHP_METHOD(gmagick, setresolution)
         double x_resolution, y_resolution;
 
         /* Parse parameters given to function */
-        if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &x_resolution, &y_resolution) == FAILURE) {
+        if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &x_resolution, &y_resolution) == FAILURE) {
                 return;
         }
 
@@ -4594,7 +4594,7 @@ PHP_METHOD(gmagick, adaptivethresholdimage)
 	long width, height, offset;
 	unsigned int status;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "lll", &width, &height, &offset) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "lll", &width, &height, &offset) == FAILURE) {
 		return;
 	}
 
@@ -4605,7 +4605,7 @@ PHP_METHOD(gmagick, adaptivethresholdimage)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to adaptive threshold image" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to adaptive threshold image");
 		return;
 	}
 
@@ -4624,7 +4624,7 @@ PHP_METHOD(gmagick, affinetransformimage)
 	php_gmagickdraw_object *internd;
 	unsigned int status;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O", &objvar, php_gmagickdraw_sc_entry) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &objvar, php_gmagickdraw_sc_entry) == FAILURE) {
 		return;
 	}
 
@@ -4636,7 +4636,7 @@ PHP_METHOD(gmagick, affinetransformimage)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to affine transform image" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to affine transform image");
 		return;
 	}
 
@@ -4662,7 +4662,7 @@ PHP_METHOD(gmagick, averageimages)
 	tmp_wand = MagickAverageImages(intern->magick_wand);
 
 	if (tmp_wand == NULL) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Averaging images failed" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Averaging images failed");
 		return;
 	}
 
@@ -4685,7 +4685,7 @@ PHP_METHOD(gmagick, blackthresholdimage)
 	php_gmagickpixel_object *color;
 	//zend_bool allocated;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &param) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &param) == FAILURE) {
 		return;
 	}
 
@@ -4698,7 +4698,7 @@ PHP_METHOD(gmagick, blackthresholdimage)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to black threshold image" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to black threshold image");
 		return;
 	}
 
@@ -4719,7 +4719,7 @@ PHP_METHOD(gmagick, colordecisionlist)
 	int ccc_len;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &color_correction_collection, &ccc_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &color_correction_collection, &ccc_len) == FAILURE) {
 		return;
 	}
 
@@ -4727,7 +4727,7 @@ PHP_METHOD(gmagick, colordecisionlist)
 	status = MagickCdlImage(intern->magick_wand, color_correction_collection);
 
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to colorDecisionListImage" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to colorDecisionListImage");
 		return;
 	}
 
@@ -4755,7 +4755,7 @@ PHP_METHOD(gmagick, clipimage)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to clip image" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to clip image");
 		return;
 	}
 	RETURN_TRUE;
@@ -4774,7 +4774,7 @@ PHP_METHOD(gmagick, clippathimage)
 	unsigned int status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sb", &clip_path, &clip_path_len, &inside) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sb", &clip_path, &clip_path_len, &inside) == FAILURE) {
 		return;
 	}
 
@@ -4784,7 +4784,7 @@ PHP_METHOD(gmagick, clippathimage)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to clip path image" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to clip path image");
 		return;
 	}
 
@@ -4808,7 +4808,7 @@ PHP_METHOD(gmagick, colorfloodfillimage)
 	php_gmagickpixel_object *border;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zdzll", &fill_param, &fuzz, &border_param, &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zdzll", &fill_param, &fuzz, &border_param, &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -4822,7 +4822,7 @@ PHP_METHOD(gmagick, colorfloodfillimage)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to color floodfill image" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to color floodfill image");
 		return;
 	}
 	RETURN_TRUE;
@@ -4845,7 +4845,7 @@ PHP_METHOD(gmagick, colorizeimage)
 	php_gmagickpixel_object *opacity;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zz", &color_param, &opacity_param) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zz", &color_param, &opacity_param) == FAILURE) {
 		return;
 	}
 
@@ -4859,7 +4859,7 @@ PHP_METHOD(gmagick, colorizeimage)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to colorize image" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to colorize image");
 		return;
 	}
 	RETURN_TRUE;
@@ -4885,7 +4885,7 @@ PHP_METHOD(gmagick, compareimagechannels)
 	zval *pNewWand;
 
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Oll", &objvar, php_gmagick_sc_entry, &channel_type, &metric_type) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Oll", &objvar, php_gmagick_sc_entry, &channel_type, &metric_type) == FAILURE) {
 		return;
 	}
 
@@ -4899,7 +4899,7 @@ PHP_METHOD(gmagick, compareimagechannels)
 	tmp_wand = MagickCompareImageChannels(intern->magick_wand, intern_second->magick_wand, channel_type, metric_type, &distortion);
 
 	if (!tmp_wand) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Compare image channels failed" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Compare image channels failed");
 		return;
 	}
 
@@ -4940,7 +4940,7 @@ PHP_METHOD(gmagick, compareimages)
 
 	zval *pNewWand;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Ol", &objvar, php_gmagick_sc_entry, &metric_type) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Ol", &objvar, php_gmagick_sc_entry, &metric_type) == FAILURE) {
 		return;
 	}
 
@@ -4962,7 +4962,7 @@ PHP_METHOD(gmagick, compareimages)
 	tmp_wand = MagickCompareImages(intern->magick_wand, intern_second->magick_wand, metric_type, &distortion);
 
 	if (!tmp_wand) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Compare images failed" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Compare images failed");
 		return;
 	}
 
@@ -4987,7 +4987,7 @@ PHP_METHOD(gmagick, contrastimage)
 	zend_bool contrast;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "b", &contrast) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "b", &contrast) == FAILURE) {
 		return;
 	}
 
@@ -4998,7 +4998,7 @@ PHP_METHOD(gmagick, contrastimage)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to contrast image" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to contrast image");
 		return;
 	}
 	RETURN_TRUE;
@@ -5018,17 +5018,17 @@ PHP_METHOD(gmagick, convolveimage)
 	long num_elements = 0;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a",  &kernel_array) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "a",  &kernel_array) == FAILURE) {
 		return;
 	}
 
 	intern = Z_GMAGICK_OBJ_P(getThis());
 	GMAGICK_CHECK_NOT_EMPTY(intern->magick_wand, 1, 1);
 
-	kernel = php_gmagick_zval_to_double_array(kernel_array, &num_elements TSRMLS_CC);
+	kernel = php_gmagick_zval_to_double_array(kernel_array, &num_elements);
 
 	if (!kernel) {
-		zend_throw_exception(php_gmagick_exception_class_entry, "Unable to read matrix array", 1 TSRMLS_CC);
+		zend_throw_exception(php_gmagick_exception_class_entry, "Unable to read matrix array", 1);
 		return;
 	}
 
@@ -5038,7 +5038,7 @@ PHP_METHOD(gmagick, convolveimage)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to convolve image" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to convolve image");
 		return;
 	}
 
@@ -5056,7 +5056,7 @@ PHP_METHOD(gmagick, extentimage)
 	long width, height, x, y;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "llll", &width, &height, &x, &y) == FAILURE)
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "llll", &width, &height, &x, &y) == FAILURE)
 	{
 		return;
 	}
@@ -5067,7 +5067,7 @@ PHP_METHOD(gmagick, extentimage)
 	status = MagickExtentImage(intern->magick_wand, width, height, x, y);
 
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to extent image" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to extent image");
 		return;
 	}
 
@@ -5086,7 +5086,7 @@ PHP_METHOD(gmagick, getimageattribute)
 	size_t key_len;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &key, &key_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &key, &key_len) == FAILURE) {
 		return;
 	}
 
@@ -5114,7 +5114,7 @@ PHP_METHOD(gmagick, getimagechannelextrema)
 	size_t minima, maxima;
 	unsigned int status;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &channel_type) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &channel_type) == FAILURE) {
 		return;
 	}
 
@@ -5124,7 +5124,7 @@ PHP_METHOD(gmagick, getimagechannelextrema)
 	status = MagickGetImageChannelExtrema(intern->magick_wand, channel_type, &minima, &maxima);
 
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to get image channel extrema" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to get image channel extrema");
 		return;
 	}
 
@@ -5146,7 +5146,7 @@ PHP_METHOD(gmagick, getimagechannelmean)
 	double mean, standard_deviation;
 	unsigned int status;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &channel_type) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &channel_type) == FAILURE) {
 		return;
 	}
 
@@ -5156,7 +5156,7 @@ PHP_METHOD(gmagick, getimagechannelmean)
 	status = MagickGetImageChannelMean(intern->magick_wand, channel_type, &mean, &standard_deviation);
 
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to get image channel mean" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to get image channel mean");
 		return;
 	}
 
@@ -5179,7 +5179,7 @@ PHP_METHOD(gmagick, getimagecolormapcolor)
 	PixelWand *tmp_wand;
 	long index;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &index) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &index) == FAILURE) {
 		return;
 	}
 
@@ -5190,13 +5190,13 @@ PHP_METHOD(gmagick, getimagecolormapcolor)
 	status = MagickGetImageColormapColor(intern->magick_wand, index , tmp_wand);
 
 	if (tmp_wand == (PixelWand *)NULL) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to get image colormap color" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to get image colormap color");
 		return;
 	}
 
 	if (status == MagickFalse) {
 		DestroyPixelWand(tmp_wand);
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to get image colormap color" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to get image colormap color");
 		return;
 	}
 
@@ -5259,7 +5259,7 @@ PHP_METHOD(gmagick, haldclutimage)
 	//long channel = DefaultChannels;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O", &objvar, php_gmagick_sc_entry) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &objvar, php_gmagick_sc_entry) == FAILURE) {
 		return;
 	}
 
@@ -5275,7 +5275,7 @@ PHP_METHOD(gmagick, haldclutimage)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to hald clut image" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to hald clut image");
 		return;
 	}
 	RETURN_TRUE;
@@ -5296,7 +5296,7 @@ PHP_METHOD(gmagick, mattefloodfillimage)
 	php_gmagickpixel_object *color;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ddzll", &alpha, &fuzz, &param, &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ddzll", &alpha, &fuzz, &param, &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -5309,7 +5309,7 @@ PHP_METHOD(gmagick, mattefloodfillimage)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to matte floodfill image" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to matte floodfill image");
 		return;
 	}
 	RETURN_TRUE;
@@ -5330,7 +5330,7 @@ PHP_METHOD(gmagick, montageimage)
 	size_t tile_geometry_len, thumbnail_geometry_len, frame_len;
 	long montage_mode = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Ossls", &objvar, php_gmagickdraw_sc_entry,
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Ossls", &objvar, php_gmagickdraw_sc_entry,
 		&tile_geometry, &tile_geometry_len,
 		&thumbnail_geometry, &thumbnail_geometry_len,
 		&montage_mode,
@@ -5347,7 +5347,7 @@ PHP_METHOD(gmagick, montageimage)
 	tmp_wand = MagickMontageImage(intern->magick_wand, internd->drawing_wand, tile_geometry, thumbnail_geometry, montage_mode, frame);
 
 	if (tmp_wand == NULL) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Montage image failed" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Montage image failed");
 		return;
 	}
 
@@ -5368,7 +5368,7 @@ PHP_METHOD(gmagick, morphimages)
 	php_gmagick_object *intern, *intern_return;
 	long frames;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &frames) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &frames) == FAILURE) {
 		return;
 	}
 
@@ -5378,7 +5378,7 @@ PHP_METHOD(gmagick, morphimages)
 	tmp_wand = MagickMorphImages(intern->magick_wand, frames);
 
 	if (!tmp_wand) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Morphing images failed" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Morphing images failed");
 		return;
 	}
 
@@ -5410,7 +5410,7 @@ PHP_METHOD(gmagick, mosaicimages)
 	tmp_wand = MagickMosaicImages(intern->magick_wand);
 
 	if (!tmp_wand) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Mosaic image failed" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Mosaic image failed");
 		return;
 	}
 
@@ -5432,7 +5432,7 @@ PHP_METHOD(gmagick, setimageattribute)
 	unsigned int status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss", &key, &key_len, &attribute, &attribute_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss", &key, &key_len, &attribute, &attribute_len) == FAILURE) {
 		return;
 	}
 
@@ -5443,7 +5443,7 @@ PHP_METHOD(gmagick, setimageattribute)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to set image attribute" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to set image attribute");
 		return;
 	}
 	RETURN_TRUE;
@@ -5462,7 +5462,7 @@ PHP_METHOD(gmagick, setimagecolormapcolor)
 	php_gmagickpixel_object *color;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "lz", &index, &param) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "lz", &index, &param) == FAILURE) {
 		return;
 	}
 
@@ -5474,7 +5474,7 @@ PHP_METHOD(gmagick, setimagecolormapcolor)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to set image color map color" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to set image color map color");
 		return;
 	}
 	RETURN_TRUE;
@@ -5491,7 +5491,7 @@ PHP_METHOD(gmagick, setimagegravity)
 	unsigned int status;
 	long gravity;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &gravity) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &gravity) == FAILURE) {
 		return;
 	}
 
@@ -5501,7 +5501,7 @@ PHP_METHOD(gmagick, setimagegravity)
 	status = MagickSetImageGravity(intern->magick_wand, gravity);
 
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to set image gravity" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to set image gravity");
 		return;
 	}
 
@@ -5520,7 +5520,7 @@ PHP_METHOD(gmagick, setimagemattecolor)
 	unsigned int status;
 	php_gmagickpixel_object *color;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &param) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &param) == FAILURE) {
 		return;
 	}
 
@@ -5533,7 +5533,7 @@ PHP_METHOD(gmagick, setimagemattecolor)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to set image matte color" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to set image matte color");
 		return;
 	}
 
@@ -5550,7 +5550,7 @@ PHP_METHOD(gmagick, setimagevirtualpixelmethod)
 	long virtual_pixel;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &virtual_pixel) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &virtual_pixel) == FAILURE) {
 		return;
 	}
 
@@ -5571,7 +5571,7 @@ PHP_METHOD(gmagick, shaveimage)
 	long columns, rows;
 	unsigned int status;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll", &columns, &rows) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ll", &columns, &rows) == FAILURE) {
 		return;
 	}
 
@@ -5582,7 +5582,7 @@ PHP_METHOD(gmagick, shaveimage)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to shave image" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to shave image");
 		return;
 	}
 
@@ -5600,7 +5600,7 @@ PHP_METHOD(gmagick, steganoimage)
 	long offset;
 	MagickWand *tmp_wand;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Ol", &objvar, php_gmagick_sc_entry, &offset) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Ol", &objvar, php_gmagick_sc_entry, &offset) == FAILURE) {
 		return;
 	}
 
@@ -5614,7 +5614,7 @@ PHP_METHOD(gmagick, steganoimage)
 	tmp_wand = MagickSteganoImage(intern->magick_wand, intern_second->magick_wand, offset);
 
 	if (!tmp_wand) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Stegano image failed" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Stegano image failed");
 		return;
 	}
 
@@ -5635,7 +5635,7 @@ PHP_METHOD(gmagick, stereoimage)
 	php_gmagick_object *intern, *intern_second, *intern_return;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O", &magick_object, php_gmagick_sc_entry) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &magick_object, php_gmagick_sc_entry) == FAILURE) {
 		return;
 	}
 
@@ -5649,7 +5649,7 @@ PHP_METHOD(gmagick, stereoimage)
 	tmp_wand = MagickStereoImage(intern->magick_wand, intern_second->magick_wand);
 
 	if (tmp_wand == NULL) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Stereo image failed" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Stereo image failed");
 		return;
 	}
 
@@ -5673,7 +5673,7 @@ PHP_METHOD(gmagick, transformimage)
 	php_gmagick_object *intern, *intern_return;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss", &crop, &crop_len, &geometry, &geometry_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss", &crop, &crop_len, &geometry, &geometry_len) == FAILURE) {
 		return;
 	}
 
@@ -5683,7 +5683,7 @@ PHP_METHOD(gmagick, transformimage)
 	transformed = MagickTransformImage(intern->magick_wand, crop, geometry);
 
 	if (!transformed) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Transforming image failed" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Transforming image failed");
 		return;
 	}
 
@@ -5706,7 +5706,7 @@ PHP_METHOD(gmagick, waveimage)
 	unsigned int status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &amplitude, &wave_length) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &amplitude, &wave_length) == FAILURE) {
 		return;
 	}
 
@@ -5717,7 +5717,7 @@ PHP_METHOD(gmagick, waveimage)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to wave image" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to wave image");
 		return;
 	}
 
@@ -5736,7 +5736,7 @@ PHP_METHOD(gmagick, whitethresholdimage)
 	unsigned int status;
 	php_gmagickpixel_object *color;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &param) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &param) == FAILURE) {
 		return;
 	}
 
@@ -5748,7 +5748,7 @@ PHP_METHOD(gmagick, whitethresholdimage)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to white threshold image" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to white threshold image");
 		return;
 	}
 
@@ -5771,7 +5771,7 @@ PHP_METHOD(gmagick, getimageboundingbox)
 
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &fuzz) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &fuzz) == FAILURE) {
 		return;
 	}
 
@@ -5853,7 +5853,7 @@ PHP_METHOD(gmagick, setdepth)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &depth) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &depth) == FAILURE) {
 		return;
 	}
 
@@ -5879,7 +5879,7 @@ PHP_METHOD(gmagick, setimagefuzz)
 	MagickBool status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &fuzz) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &fuzz) == FAILURE) {
 		return;
 	}
 
@@ -5909,7 +5909,7 @@ PHP_METHOD(gmagick, setimageoption)
 	unsigned int	 status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sss", 
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sss", 
 			&format, &format_len,
 			&key, &key_len,
 			&value, &value_len) == FAILURE) {
@@ -5922,7 +5922,7 @@ PHP_METHOD(gmagick, setimageoption)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to set format" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to set format");
 		return;
 	}
 
@@ -5941,7 +5941,7 @@ PHP_METHOD(gmagick, setimagesavedtype)
 	unsigned int status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &type) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &type) == FAILURE) {
 		return;
 	}
 
@@ -5952,7 +5952,7 @@ PHP_METHOD(gmagick, setimagesavedtype)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to set format" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to set format");
 		return;
 	}
 
@@ -5975,7 +5975,7 @@ PHP_METHOD(gmagick, setformat)
 	unsigned int  status;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &format, &format_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &format, &format_len) == FAILURE) {
 		return;
 	}
 
@@ -5984,7 +5984,7 @@ PHP_METHOD(gmagick, setformat)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to set format" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to set format");
 		return;
 	}
 
@@ -6004,7 +6004,7 @@ PHP_METHOD(gmagick, setresolutionunits)
 	int resolution_type;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &resolution_type) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &resolution_type) == FAILURE) {
 		return;
 	}
 
@@ -6013,7 +6013,7 @@ PHP_METHOD(gmagick, setresolutionunits)
 
 	/* No magick is going to happen */
 	if (status == MagickFalse) {
-		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to set resolution" TSRMLS_CC);
+		GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to set resolution");
 		return;
 	}
 	RETURN_TRUE;
@@ -6035,7 +6035,7 @@ PHP_METHOD(gmagick, writeimagefile)
 	size_t format_len;
 	char *orig_name = NULL, *buffer;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r|s!", &zstream, &format, &format_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "r|s!", &zstream, &format, &format_len) == FAILURE) {
 		return;
 	}
 
@@ -6052,7 +6052,7 @@ PHP_METHOD(gmagick, writeimagefile)
 	}
 
 	php_stream_from_zval(stream, zstream);
-	result = php_gmagick_stream_handler(intern, stream, GmagickWriteImageFile TSRMLS_CC);
+	result = php_gmagick_stream_handler(intern, stream, GmagickWriteImageFile);
 
 	/* Restore the original name after write */
 	if (orig_name) {
@@ -6062,7 +6062,7 @@ PHP_METHOD(gmagick, writeimagefile)
 
 	if (result == 0) {
 		if (!EG(exception)) {
-			GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to write image to the filehandle" TSRMLS_CC);
+			GMAGICK_THROW_GMAGICK_EXCEPTION(intern->magick_wand, "Unable to write image to the filehandle");
 			return;
 		}
 		return;

--- a/gmagickdraw_methods.c
+++ b/gmagickdraw_methods.c
@@ -30,7 +30,7 @@ PHP_METHOD(gmagickdraw, setstrokecolor)
 	php_gmagickdraw_object *internd;
 	php_gmagickpixel_object *internp;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &param) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &param) == FAILURE) {
 		return;
 	}
 
@@ -54,7 +54,7 @@ PHP_METHOD(gmagickdraw, setstrokewidth)
 	php_gmagickdraw_object *internd;
 	double width;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &width) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &width) == FAILURE) {
 		return;
 	}
 
@@ -75,7 +75,7 @@ PHP_METHOD(gmagickdraw, ellipse)
 	php_gmagickdraw_object *internd;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dddddd", &ox, &oy, &rx, &ry, &start, &end) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dddddd", &ox, &oy, &rx, &ry, &start, &end) == FAILURE) {
 		return;
 	}
 
@@ -98,7 +98,7 @@ PHP_METHOD(gmagickdraw, annotate)
 	size_t text_len;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dds", &x, &y, &text, &text_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dds", &x, &y, &text, &text_len) == FAILURE) {
 		return;
 	}
 
@@ -124,7 +124,7 @@ PHP_METHOD(gmagickdraw, affine)
 	AffineMatrix *pmatrix;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &affine_matrix) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "a", &affine_matrix) == FAILURE) {
 		return;
 	}
 
@@ -177,7 +177,7 @@ PHP_METHOD(gmagickdraw, arc)
 	double sx, sy, ex, ey, sd, ed;
 	php_gmagickdraw_object *internd;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dddddd", &sx, &sy, &ex, &ey, &sd, &ed) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dddddd", &sx, &sy, &ex, &ey, &sd, &ed) == FAILURE) {
 		return;
 	}
 
@@ -200,10 +200,10 @@ PHP_METHOD(gmagickdraw, bezier)
 	int num_elements = 0;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &coordinate_array) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "a", &coordinate_array) == FAILURE) {
 		return;
 	}
-	coordinates = get_pointinfo_array(coordinate_array, &num_elements TSRMLS_CC);
+	coordinates = get_pointinfo_array(coordinate_array, &num_elements);
 
 	if (coordinates == (PointInfo *)NULL) {
 		GMAGICK_THROW_EXCEPTION_WITH_MESSAGE(GMAGICKDRAW_CLASS, "Unable to read coordinate array", 2);
@@ -226,7 +226,7 @@ PHP_METHOD(gmagickdraw, getfillcolor)
 	php_gmagickdraw_object *internd;
 	PixelWand *tmp_wand;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 	
@@ -251,7 +251,7 @@ PHP_METHOD(gmagickdraw, getfillopacity)
 	php_gmagickdraw_object *internd;
 	double opacity;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -270,7 +270,7 @@ PHP_METHOD(gmagickdraw, getfont)
 	php_gmagickdraw_object *internd;
 	char *font;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -295,7 +295,7 @@ PHP_METHOD(gmagickdraw, getfontsize)
 	php_gmagickdraw_object *internd;
 	double font_size;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -315,7 +315,7 @@ PHP_METHOD(gmagickdraw, getfontstyle)
 	php_gmagickdraw_object *internd;
 	long font_style;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -335,7 +335,7 @@ PHP_METHOD(gmagickdraw, getfontweight)
 	php_gmagickdraw_object *internd;
 	long weight;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -355,7 +355,7 @@ PHP_METHOD(gmagickdraw, getstrokeopacity)
 	php_gmagickdraw_object *internd;
 	double opacity;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -375,7 +375,7 @@ PHP_METHOD(gmagickdraw, getstrokecolor)
 	php_gmagickdraw_object *internd;
 	PixelWand *tmp_wand;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -400,7 +400,7 @@ PHP_METHOD(gmagickdraw, getstrokewidth)
 	php_gmagickdraw_object *internd;
 	double width;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -419,7 +419,7 @@ PHP_METHOD(gmagickdraw, gettextdecoration)
 	php_gmagickdraw_object *internd;
 	long decoration;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -439,7 +439,7 @@ PHP_METHOD(gmagickdraw, gettextencoding)
 	php_gmagickdraw_object *internd;
 	char *encoding;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -464,7 +464,7 @@ PHP_METHOD(gmagickdraw, line)
 	php_gmagickdraw_object *internd;
 	double sx, sy, ex, ey;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dddd", &sx, &sy, &ex, &ey) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dddd", &sx, &sy, &ex, &ey) == FAILURE) {
 		return;
 	}
 
@@ -485,7 +485,7 @@ PHP_METHOD(gmagickdraw, point)
 	double x, y;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -507,11 +507,11 @@ PHP_METHOD(gmagickdraw, polygon)
 	int num_elements = 0;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &coordinate_array) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "a", &coordinate_array) == FAILURE) {
 		return;
 	}
 
-	coordinates = get_pointinfo_array(coordinate_array, &num_elements TSRMLS_CC);
+	coordinates = get_pointinfo_array(coordinate_array, &num_elements);
 
 	if (coordinates == (PointInfo *)NULL) {
 		GMAGICK_THROW_EXCEPTION_WITH_MESSAGE(GMAGICKDRAW_CLASS, "Unable to read coordinate array", 2);
@@ -537,11 +537,11 @@ PHP_METHOD(gmagickdraw, polyline)
 	int num_elements = 0;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &coordinate_array) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "a", &coordinate_array) == FAILURE) {
 		return;
 	}
 
-	coordinates = get_pointinfo_array(coordinate_array, &num_elements TSRMLS_CC);
+	coordinates = get_pointinfo_array(coordinate_array, &num_elements);
 
 	if (coordinates == (PointInfo *)NULL) {
 		GMAGICK_THROW_EXCEPTION_WITH_MESSAGE(GMAGICKDRAW_CLASS, "Unable to read coordinate array", 2);
@@ -565,7 +565,7 @@ PHP_METHOD(gmagickdraw, rectangle)
 	php_gmagickdraw_object *internd;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dddd", &x1, &y1, &x2, &y2) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dddd", &x1, &y1, &x2, &y2) == FAILURE) {
 		return;
 	}
 
@@ -585,7 +585,7 @@ PHP_METHOD(gmagickdraw, rotate)
 	double degrees;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &degrees) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &degrees) == FAILURE) {
 		return;
 	}
 
@@ -605,7 +605,7 @@ PHP_METHOD(gmagickdraw, roundrectangle)
 	php_gmagickdraw_object *internd;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dddddd", &x1, &y1, &x2, &y2, &rx, &ry) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dddddd", &x1, &y1, &x2, &y2, &rx, &ry) == FAILURE) {
 		return;
 	}
 
@@ -625,7 +625,7 @@ PHP_METHOD(gmagickdraw, scale)
 	double x, y;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -643,7 +643,7 @@ PHP_METHOD(gmagickdraw, setfillcolor)
 	php_gmagickdraw_object *internd;
 	php_gmagickpixel_object *internp;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &param) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &param) == FAILURE) {
 		return;
 	}
 
@@ -665,7 +665,7 @@ PHP_METHOD(gmagickdraw, setfillopacity)
 	double fillOpacity;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &fillOpacity) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &fillOpacity) == FAILURE) {
 		return;
 	}
 
@@ -687,7 +687,7 @@ PHP_METHOD(gmagickdraw, setfont)
 	int error = 0;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &font, &font_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &font, &font_len) == FAILURE) {
 		return;
 	}
 
@@ -699,9 +699,9 @@ PHP_METHOD(gmagickdraw, setfont)
 	internd = Z_GMAGICKDRAW_OBJ_P(getThis());
 
 	/* And if it wasn't */
-	if (!check_configured_font(font, font_len TSRMLS_CC)) {
+	if (!check_configured_font(font, font_len)) {
 
-		if (!(absolute = expand_filepath(font, NULL TSRMLS_CC))) {
+		if (!(absolute = expand_filepath(font, NULL))) {
 			GMAGICK_THROW_EXCEPTION_WITH_MESSAGE(GMAGICKDRAW_CLASS, "Unable to set font", 2);
 		}
 
@@ -710,7 +710,7 @@ PHP_METHOD(gmagickdraw, setfont)
 		GMAGICKDRAW_CHECK_READ_OR_WRITE_ERROR(internd, absolute, error, GMAGICK_FREE_FILENAME);
 
 		if (VCWD_ACCESS(absolute, F_OK|R_OK)) {
-			zend_throw_exception_ex(php_gmagickdraw_exception_class_entry, 2 TSRMLS_CC,
+			zend_throw_exception_ex(php_gmagickdraw_exception_class_entry, 2,
 				"The given font is not found in the GraphicsMagick configuration and the file (%s) is not accessible", absolute);
 
 			efree(absolute);
@@ -737,7 +737,7 @@ PHP_METHOD(gmagickdraw, setfontsize)
 	double font_size;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &font_size) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &font_size) == FAILURE) {
 		return;
 	}
 
@@ -757,7 +757,7 @@ PHP_METHOD(gmagickdraw, setfontstyle)
 	zend_long style_id = AnyStyle;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &style_id) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &style_id) == FAILURE) {
 		return;
 	}
 
@@ -777,7 +777,7 @@ PHP_METHOD(gmagickdraw, setfontweight)
 	zend_long weight;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &weight) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &weight) == FAILURE) {
 		return;
 	}
 
@@ -803,7 +803,7 @@ PHP_METHOD(gmagickdraw, setstrokeopacity)
 	double opacity;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &opacity) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &opacity) == FAILURE) {
 		return;
 	}
 
@@ -823,7 +823,7 @@ PHP_METHOD(gmagickdraw, settextdecoration)
 	zend_long decoration;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &decoration) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &decoration) == FAILURE) {
 		return;
 	}
 
@@ -843,7 +843,7 @@ PHP_METHOD(gmagickdraw, setgravity)
 	php_gmagickdraw_object *internd;
 	zend_long gravity;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &gravity) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &gravity) == FAILURE) {
 		return;
 	}
 
@@ -862,7 +862,7 @@ PHP_METHOD(gmagickdraw, getgravity)
 {
 	php_gmagickdraw_object *internd;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -881,7 +881,7 @@ PHP_METHOD(gmagickdraw, settextencoding)
 	char *encoding;
 	size_t encoding_len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &encoding, &encoding_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &encoding, &encoding_len) == FAILURE) {
 		return;
 	}
 
@@ -901,7 +901,7 @@ PHP_METHOD(gmagickdraw, setstrokeantialias)
 	zend_bool antialias;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "b", &antialias) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "b", &antialias) == FAILURE) {
 		return;
 	}
 
@@ -922,7 +922,7 @@ PHP_METHOD(gmagickdraw, setstrokedashoffset)
 	double offset;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &offset) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &offset) == FAILURE) {
 		return;
 	}
 
@@ -942,7 +942,7 @@ PHP_METHOD(gmagickdraw, setstrokelinecap)
 	zend_long line_cap;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &line_cap) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &line_cap) == FAILURE) {
 		return;
 	}
 	
@@ -962,7 +962,7 @@ PHP_METHOD(gmagickdraw, setstrokelinejoin)
 	zend_long line_join;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &line_join) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &line_join) == FAILURE) {
 		return;
 	}
 	
@@ -982,7 +982,7 @@ PHP_METHOD(gmagickdraw, setstrokemiterlimit)
 	zend_long miter_limit;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &miter_limit) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &miter_limit) == FAILURE) {
 		return;
 	}
 	
@@ -1132,11 +1132,11 @@ PHP_METHOD(gmagickdraw, setstrokedasharray)
 	php_gmagickdraw_object *internd;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &param_array) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "a", &param_array) == FAILURE) {
 		return;
 	}
 
-	double_array = php_gmagick_zval_to_double_array(param_array, &elements TSRMLS_CC);
+	double_array = php_gmagick_zval_to_double_array(param_array, &elements);
 
 	if (!double_array) {
 		GMAGICK_THROW_EXCEPTION_WITH_MESSAGE(GMAGICKDRAW_CLASS, "Cannot read stroke dash array parameter", 2);		
@@ -1164,7 +1164,7 @@ PHP_METHOD(gmagickdraw, circle)
 	php_gmagickdraw_object *internd;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dddd", &ox, &oy, &px, &py) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dddd", &ox, &oy, &px, &py) == FAILURE) {
 		return;
 	}
 
@@ -1211,7 +1211,7 @@ PHP_METHOD(gmagickdraw, setclippath)
 	size_t clip_mask_len;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &clip_mask, &clip_mask_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &clip_mask, &clip_mask_len) == FAILURE) {
 		return;
 	}
 
@@ -1250,7 +1250,7 @@ PHP_METHOD(gmagickdraw, setcliprule)
 	zend_long fill_rule;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &fill_rule) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &fill_rule) == FAILURE) {
 		return;
 	}
 	
@@ -1289,7 +1289,7 @@ PHP_METHOD(gmagickdraw, setclipunits)
 	zend_long units;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &units) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &units) == FAILURE) {
 		return;
 	}
 
@@ -1310,7 +1310,7 @@ PHP_METHOD(gmagickdraw, color)
 	long paint_method;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ddl", &x, &y, &paint_method) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ddl", &x, &y, &paint_method) == FAILURE) {
 		return;
 	}
 
@@ -1331,7 +1331,7 @@ PHP_METHOD(gmagickdraw, comment)
 	size_t comment_len;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &comment, &comment_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &comment, &comment_len) == FAILURE) {
 		return;
 	}
 	
@@ -1353,7 +1353,7 @@ PHP_METHOD(gmagickdraw, setfillpatternurl)
 	size_t url_len;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &url, &url_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &url, &url_len) == FAILURE) {
 		return;
 	}
 
@@ -1393,7 +1393,7 @@ PHP_METHOD(gmagickdraw, setfillrule)
 	zend_long fill_rule;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &fill_rule) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &fill_rule) == FAILURE) {
 		return;
 	}
 	
@@ -1429,7 +1429,7 @@ PHP_METHOD(gmagickdraw, getfontfamily)
 }
 /* }}} */
 
-static zend_bool php_gmagick_check_font(char *font, int font_len TSRMLS_DC)
+static zend_bool php_gmagick_check_font(char *font, int font_len)
 {
 	zend_bool retval = 0;
 	char **fonts;
@@ -1463,18 +1463,18 @@ PHP_METHOD(gmagickdraw, setfontfamily)
 	size_t font_family_len;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &font_family, &font_family_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &font_family, &font_family_len) == FAILURE) {
 		return;
 	}
 
 	/* Check that no empty string is passed */
 	if (font_family_len == 0) {
-		GMAGICK_THROW_EXCEPTION_WITH_MESSAGE(GMAGICKDRAW_CLASS, "Can not set empty font family", 2 TSRMLS_CC);
+		GMAGICK_THROW_EXCEPTION_WITH_MESSAGE(GMAGICKDRAW_CLASS, "Can not set empty font family", 2);
 		return;
 	}
 
-	if (!php_gmagick_check_font(font_family, font_family_len TSRMLS_CC )) {
-		GMAGICK_THROW_EXCEPTION_WITH_MESSAGE(GMAGICKDRAW_CLASS, "Unable to set font family; parameter not found in the list of configured fonts", 2 TSRMLS_CC);
+	if (!php_gmagick_check_font(font_family, font_family_len )) {
+		GMAGICK_THROW_EXCEPTION_WITH_MESSAGE(GMAGICKDRAW_CLASS, "Unable to set font family; parameter not found in the list of configured fonts", 2);
 		return;
 	}
 
@@ -1506,7 +1506,7 @@ PHP_METHOD(gmagickdraw, setfontstretch)
 	zend_long stretch;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &stretch) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &stretch) == FAILURE) {
 		return;
 	}
 
@@ -1532,7 +1532,7 @@ PHP_METHOD(gmagickdraw, setfontstretch)
 //	double x, y, width, height;
 //
 //	/* Parse parameters given to function */
-//	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "lddddO", &compose, &x, &y, &width, &height, &magick_obj, php_gmagick_sc_entry) == FAILURE) {
+//	if (zend_parse_parameters(ZEND_NUM_ARGS(), "lddddO", &compose, &x, &y, &width, &height, &magick_obj, php_gmagick_sc_entry) == FAILURE) {
 //		return;
 //	}
 //
@@ -1577,7 +1577,7 @@ PHP_METHOD(gmagickdraw, pathcurvetoabsolute)
 	double x1, y1, x2, y2, x, y;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dddddd", &x1, &y1, &x2, &y2, &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dddddd", &x1, &y1, &x2, &y2, &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -1597,7 +1597,7 @@ PHP_METHOD(gmagickdraw, pathcurvetorelative)
 	double x1, y1, x2, y2, x, y;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dddddd", &x1, &y1, &x2, &y2, &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dddddd", &x1, &y1, &x2, &y2, &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -1617,7 +1617,7 @@ PHP_METHOD(gmagickdraw, pathcurvetoquadraticbezierabsolute)
 	double x1, y1, x, y;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dddd", &x1, &y1, &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dddd", &x1, &y1, &x, &y) == FAILURE) {
 		return;
 	}
 	
@@ -1637,7 +1637,7 @@ PHP_METHOD(gmagickdraw, pathcurvetoquadraticbezierrelative)
 	double x1, y1, x, y;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dddd", &x1, &y1, &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dddd", &x1, &y1, &x, &y) == FAILURE) {
 		return;
 	}
 	
@@ -1657,7 +1657,7 @@ PHP_METHOD(gmagickdraw, pathcurvetoquadraticbeziersmoothabsolute)
 	double x, y;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -1677,7 +1677,7 @@ PHP_METHOD(gmagickdraw, pathcurvetoquadraticbeziersmoothrelative)
 	double x, y;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -1697,7 +1697,7 @@ PHP_METHOD(gmagickdraw, pathcurvetosmoothabsolute)
 	double x1, y1, x, y;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dddd", &x1, &y1, &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dddd", &x1, &y1, &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -1717,7 +1717,7 @@ PHP_METHOD(gmagickdraw, pathcurvetosmoothrelative)
 	double x1, y1, x, y;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dddd", &x1, &y1, &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dddd", &x1, &y1, &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -1738,7 +1738,7 @@ PHP_METHOD(gmagickdraw, pathellipticarcabsolute)
 	zend_bool large_arc, sweep;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dddbbdd", &rx, &ry, &x_axis_rotation, &large_arc, &sweep, &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dddbbdd", &rx, &ry, &x_axis_rotation, &large_arc, &sweep, &x, &y) == FAILURE) {
 		return;
 	}
 	
@@ -1759,7 +1759,7 @@ PHP_METHOD(gmagickdraw, pathellipticarcrelative)
 	zend_bool large_arc, sweep;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dddbbdd", &rx, &ry, &x_axis_rotation, &large_arc, &sweep, &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dddbbdd", &rx, &ry, &x_axis_rotation, &large_arc, &sweep, &x, &y) == FAILURE) {
 		return;
 	}
 	
@@ -1780,7 +1780,7 @@ PHP_METHOD(gmagickdraw, pathmovetoabsolute)
 	double x, y;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -1800,7 +1800,7 @@ PHP_METHOD(gmagickdraw, pathmovetorelative)
 	double x, y;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -1821,7 +1821,7 @@ PHP_METHOD(gmagickdraw, pathlinetoabsolute)
 	double x, y;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &x, &y) == FAILURE) {
 		return;
 	}
 	
@@ -1841,7 +1841,7 @@ PHP_METHOD(gmagickdraw, pathlinetorelative)
 	double x, y;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -1862,7 +1862,7 @@ PHP_METHOD(gmagickdraw, pathlinetohorizontalabsolute)
 	double y;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d",  &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d",  &y) == FAILURE) {
 		return;
 	}
 	
@@ -1882,7 +1882,7 @@ PHP_METHOD(gmagickdraw, pathlinetohorizontalrelative)
 	double x;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &x) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &x) == FAILURE) {
 		return;
 	}
 	
@@ -1904,7 +1904,7 @@ PHP_METHOD(gmagickdraw, pathlinetoverticalabsolute)
 	double y;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &y) == FAILURE) {
 		return;
 	}
 
@@ -1924,7 +1924,7 @@ PHP_METHOD(gmagickdraw, pathlinetoverticalrelative)
 	double y;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &y) == FAILURE) {
 		return;
 	}
 	
@@ -2037,7 +2037,7 @@ PHP_METHOD(gmagickdraw, pushclippath)
 	size_t clip_mask_len;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &clip_mask, &clip_mask_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &clip_mask, &clip_mask_len) == FAILURE) {
 		return;
 	}
 
@@ -2076,7 +2076,7 @@ PHP_METHOD(gmagickdraw, pushpattern)
 	double x, y, width, height;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sdddd", &pattern_id, &pattern_id_len, &x, &y, &width, &height) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "sdddd", &pattern_id, &pattern_id_len, &x, &y, &width, &height) == FAILURE) {
 		return;
 	}
 
@@ -2097,7 +2097,7 @@ PHP_METHOD(gmagickdraw, skewx)
 	php_gmagickdraw_object *internd;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &degrees) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &degrees) == FAILURE) {
 		return;
 	}
 
@@ -2117,7 +2117,7 @@ PHP_METHOD(gmagickdraw, skewy)
 	php_gmagickdraw_object *internd;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "d", &degrees) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "d", &degrees) == FAILURE) {
 		return;
 	}
 
@@ -2139,7 +2139,7 @@ PHP_METHOD(gmagickdraw, setstrokepatternurl)
 	size_t url_len;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &url, &url_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &url, &url_len) == FAILURE) {
 		return;
 	}
 
@@ -2178,7 +2178,7 @@ PHP_METHOD(gmagickdraw, settextantialias)
 	php_gmagickdraw_object *internd;
 	zend_bool antialias;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "b", &antialias) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "b", &antialias) == FAILURE) {
 		return;
 	}
 
@@ -2206,7 +2206,7 @@ PHP_METHOD(gmagickdraw, gettextundercolor)
 	tmp_wand = NewPixelWand();
 
 	if (!tmp_wand) {
-		GMAGICK_THROW_EXCEPTION_WITH_MESSAGE(GMAGICKDRAW_CLASS, "Failed to allocate space for new PixelWand", 2 TSRMLS_CC);
+		GMAGICK_THROW_EXCEPTION_WITH_MESSAGE(GMAGICKDRAW_CLASS, "Failed to allocate space for new PixelWand", 2);
 		return;
 	}
 
@@ -2229,7 +2229,7 @@ PHP_METHOD(gmagickdraw, settextundercolor)
 	php_gmagickdraw_object *internd;
 	php_gmagickpixel_object *internp;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &param) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &param) == FAILURE) {
 		return;
 	}
 
@@ -2253,7 +2253,7 @@ PHP_METHOD(gmagickdraw, translate)
 	php_gmagickdraw_object *internd;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "dd", &x, &y) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "dd", &x, &y) == FAILURE) {
 		return;
 	}
 
@@ -2273,7 +2273,7 @@ PHP_METHOD(gmagickdraw, setviewbox)
 	zend_long x1, y1, x2, y2;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "llll", &x1, &y1, &x2, &y2) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "llll", &x1, &y1, &x2, &y2) == FAILURE) {
 		return;
 	}
 

--- a/gmagickpixel_methods.c
+++ b/gmagickpixel_methods.c
@@ -31,7 +31,7 @@ PHP_METHOD(gmagickpixel, __construct)
 	char *color_name = NULL;
 	size_t color_name_len = 0;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s!", &color_name, &color_name_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|s!", &color_name, &color_name_len) == FAILURE) {
 		return;
 	}
 
@@ -59,7 +59,7 @@ PHP_METHOD(gmagickpixel, setcolor)
 	size_t color_name_len;
 	MagickBool status;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &color_name, &color_name_len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &color_name, &color_name_len) == FAILURE) {
 		return;
 	}
 
@@ -82,7 +82,7 @@ PHP_METHOD(gmagickpixel, setcolorcount)
 	php_gmagickpixel_object *internp;
 	zend_long color_count;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &color_count) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &color_count) == FAILURE) {
 		return;
 	}
 
@@ -103,7 +103,7 @@ PHP_METHOD(gmagickpixel, getcolor)
 	zend_bool as_array = 0, normalise_array = 0;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|bb", &as_array, &normalise_array) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|bb", &as_array, &normalise_array) == FAILURE) {
 		return;
 	}
 
@@ -151,7 +151,7 @@ PHP_METHOD(gmagickpixel, getcolorcount)
 	php_gmagickpixel_object *internp;
 	zend_long color_count;
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
 		return;
 	}
 
@@ -172,7 +172,7 @@ PHP_METHOD(gmagickpixel, getcolorvalue)
 	double color_value = 0;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &color) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &color) == FAILURE) {
 		return;
 	}
 
@@ -230,7 +230,7 @@ PHP_METHOD(gmagickpixel, setcolorvalue)
 	double color_value;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ld", &color, &color_value) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ld", &color, &color_value) == FAILURE) {
 		return;
 	}
 
@@ -289,7 +289,7 @@ PHP_METHOD(gmagickpixel, getcolorvaluequantum)
 	Quantum color_value_quantum = 0;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &color_quantum) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &color_quantum) == FAILURE) {
 		return;
 	}
 
@@ -330,7 +330,7 @@ PHP_METHOD(gmagickpixel, getcolorvaluequantum)
 			break;
 
 		default:
-			zend_throw_exception_ex(php_gmagickpixel_exception_class_entry, 2 TSRMLS_CC, "Unknown color type: %d", color_quantum);
+			zend_throw_exception_ex(php_gmagickpixel_exception_class_entry, 2, "Unknown color type: %d", color_quantum);
 			RETURN_NULL();
 	}
 	RETVAL_LONG(color_value_quantum);
@@ -348,7 +348,7 @@ PHP_METHOD(gmagickpixel, setcolorvaluequantum)
 	Quantum color_value_quantum;
 
 	/* Parse parameters given to function */
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ld", &color_quantum, &color_value_quantum_input) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "ld", &color_quantum, &color_value_quantum_input) == FAILURE) {
 		return;
 	}
 
@@ -391,7 +391,7 @@ PHP_METHOD(gmagickpixel, setcolorvaluequantum)
 			break;
 
 		default:
-			zend_throw_exception_ex(php_gmagickpixel_exception_class_entry, 2 TSRMLS_CC, "Unknown color type: %d", color_quantum);
+			zend_throw_exception_ex(php_gmagickpixel_exception_class_entry, 2, "Unknown color type: %d", color_quantum);
 			RETURN_NULL();
 	}
 

--- a/php_gmagick.h
+++ b/php_gmagick.h
@@ -45,10 +45,6 @@ typedef long ssize_t;
 #include "config.h"
 #endif
 
-#ifdef ZTS
-#include "TSRM.h"
-#endif
-
 #include "php.h"
 #include "php_ini.h"
 #include "Zend/zend_exceptions.h"

--- a/php_gmagick_helpers.h
+++ b/php_gmagick_helpers.h
@@ -32,30 +32,30 @@ typedef enum {
 } GmagickOperationType;
 
 #define GMAGICK_INIT_ERROR_HANDLING  zend_error_handling error_handling
-#define GMAGICK_SET_ERROR_HANDLING_THROW zend_replace_error_handling(EH_THROW, php_gmagick_exception_class_entry, &error_handling TSRMLS_CC)
-#define GMAGICK_RESTORE_ERROR_HANDLING   zend_restore_error_handling(&error_handling TSRMLS_CC)
+#define GMAGICK_SET_ERROR_HANDLING_THROW zend_replace_error_handling(EH_THROW, php_gmagick_exception_class_entry, &error_handling)
+#define GMAGICK_RESTORE_ERROR_HANDLING   zend_restore_error_handling(&error_handling)
 
 /* {{{ void php_gmagick_initialize_constants() */
 void php_gmagick_initialize_constants();
 /* }}} */
 
-/* {{{ get_pointinfo_array(zval *coordinate_array, int *num_elements TSRMLS_DC) */
-void *get_pointinfo_array(zval *coordinate_array, int *num_elements TSRMLS_DC);
+/* {{{ get_pointinfo_array(zval *coordinate_array, int *num_elements) */
+void *get_pointinfo_array(zval *coordinate_array, int *num_elements);
 /* }}} */
 
-/* {{{ check_configured_font(char *font, int font_len TSRMLS_DC ) */
-int check_configured_font(char *font, int font_len TSRMLS_DC );
+/* {{{ check_configured_font(char *font, int font_len ) */
+int check_configured_font(char *font, int font_len );
 
-/* {{{ get_double_array_from_zval(zval *param_array, long *num_elements TSRMLS_DC) */
-double *get_double_array_from_zval(zval *param_array, long *num_elements TSRMLS_DC);
+/* {{{ get_double_array_from_zval(zval *param_array, long *num_elements) */
+double *get_double_array_from_zval(zval *param_array, long *num_elements);
 
-/* {{{ count_occurences_of(char needle, char *haystack TSRMLS_DC)
+/* {{{ count_occurences_of(char needle, char *haystack)
 */
-int count_occurences_of(char needle, char *haystack TSRMLS_DC);
+int count_occurences_of(char needle, char *haystack);
 
-/* {{{ zend_bool crop_thumbnail_image(MagickWand *magick_wand, long desired_width, long desired_height TSRMLS_DC)
+/* {{{ zend_bool crop_thumbnail_image(MagickWand *magick_wand, long desired_width, long desired_height)
 */
-zend_bool crop_thumbnail_image(MagickWand *magick_wand, long desired_width, long desired_height, zend_bool legacy TSRMLS_DC);
+zend_bool crop_thumbnail_image(MagickWand *magick_wand, long desired_width, long desired_height, zend_bool legacy);
 
 /* {{{ zend_bool php_gmagick_thumbnail_dimensions(MagickWand *magick_wand, zend_bool bestfit, long desired_width, long desired_height, long *new_width, long *new_height)
 */
@@ -64,10 +64,10 @@ zend_bool php_gmagick_thumbnail_dimensions(MagickWand *magick_wand, zend_bool be
 /* {{{ zend_bool php_gmagick_ensure_not_empty (MagickWand *magick_wand) */
 zend_bool php_gmagick_ensure_not_empty (MagickWand *magick_wand);
 
-/* {{{ double *php_gmagick_zval_to_double_array(zval *param_array, long *num_elements TSRMLS_DC) */
-double *php_gmagick_zval_to_double_array(zval *param_array, long *num_elements TSRMLS_DC);
+/* {{{ double *php_gmagick_zval_to_double_array(zval *param_array, long *num_elements) */
+double *php_gmagick_zval_to_double_array(zval *param_array, long *num_elements);
 
 
-zend_bool php_gmagick_stream_handler(php_gmagick_object *intern, php_stream *stream, GmagickOperationType type TSRMLS_DC);
+zend_bool php_gmagick_stream_handler(php_gmagick_object *intern, php_stream *stream, GmagickOperationType type);
 
 #endif

--- a/php_gmagick_macros.h
+++ b/php_gmagick_macros.h
@@ -39,15 +39,15 @@
 { \
 	switch(type) { \
 		case 1: \
-			zend_throw_exception(php_gmagick_exception_class_entry, description, (long)code TSRMLS_CC); \
+			zend_throw_exception(php_gmagick_exception_class_entry, description, (long)code); \
 			RETURN_NULL(); \
 		break; \
 		case 2: \
-			zend_throw_exception(php_gmagickdraw_exception_class_entry, description, (long)code TSRMLS_CC); \
+			zend_throw_exception(php_gmagickdraw_exception_class_entry, description, (long)code); \
 			RETURN_NULL(); \
 		break; \
 		case 3: \
-			zend_throw_exception(php_gmagickpixel_exception_class_entry, description, (long)code TSRMLS_CC); \
+			zend_throw_exception(php_gmagickpixel_exception_class_entry, description, (long)code); \
 			RETURN_NULL(); \
 		break; \
 	} \
@@ -59,13 +59,13 @@
 /* {{{ GMAGICK_REGISTER_CONST_LONG(const_name, value)
 */
 #define GMAGICK_REGISTER_CONST_LONG(const_name, value) \
-	zend_declare_class_constant_long(php_gmagick_sc_entry, const_name, sizeof(const_name)-1, (long)value TSRMLS_CC);
+	zend_declare_class_constant_long(php_gmagick_sc_entry, const_name, sizeof(const_name)-1, (long)value);
 /* }}} */
 
 /* {{{ GMAGICK_REGISTER_CONST_STRING(const_name, value)
 */
 #define GMAGICK_REGISTER_CONST_STRING(const_name, value) \
-	zend_declare_class_constant_string(php_gmagick_sc_entry, const_name, sizeof(const_name)-1, value TSRMLS_CC);
+	zend_declare_class_constant_string(php_gmagick_sc_entry, const_name, sizeof(const_name)-1, value);
 /* }}} */
 
 /* {{{ GMAGICK_FREE_MEMORY(type, value)
@@ -89,9 +89,9 @@
         description = NULL; \
 	} \
 	if (!description) { \
-		zend_throw_exception(php_gmagick_exception_class_entry, fallback, 1 TSRMLS_CC); \
+		zend_throw_exception(php_gmagick_exception_class_entry, fallback, 1); \
 	} else { \
-		zend_throw_exception(php_gmagick_exception_class_entry, description, (long)severity TSRMLS_CC); \
+		zend_throw_exception(php_gmagick_exception_class_entry, description, (long)severity); \
 		GMAGICK_FREE_MEMORY(char *, description); \
 	} \
 }
@@ -191,7 +191,7 @@
 /* GraphicsMagick 1.3.3 is missing PixelGetException */
 #define GMAGICK_THROW_GMAGICKPIXEL_EXCEPTION(pixel_wand, fallback) \
 { \
-	zend_throw_exception(php_gmagickpixel_exception_class_entry, fallback, 2 TSRMLS_CC); \
+	zend_throw_exception(php_gmagickpixel_exception_class_entry, fallback, 2); \
 	RETURN_NULL(); \
 }
 /* }}} */
@@ -201,7 +201,7 @@
 /* GraphicsMagick 1.1.x is missing DrawGetException */
 #define GMAGICK_THROW_GMAGICKDRAW_EXCEPTION(drawing_wand, fallback, code) \
 { \
-	zend_throw_exception(php_gmagickdraw_exception_class_entry, fallback, 2 TSRMLS_CC); \
+	zend_throw_exception(php_gmagickdraw_exception_class_entry, fallback, 2); \
 	RETURN_NULL(); \
 }
 /* }}} */
@@ -218,10 +218,10 @@
 		GMAGICK_FREE_MEMORY(char *, description); \
 	} \
 	if (!description) { \
-		zend_throw_exception(php_gmagickdraw_exception_class_entry, fallback, (long)code TSRMLS_CC); \
+		zend_throw_exception(php_gmagickdraw_exception_class_entry, fallback, (long)code); \
 		RETURN_NULL(); \
 	} else { \
-		zend_throw_exception(php_gmagickdraw_exception_class_entry, description, (long)severity TSRMLS_CC); \
+		zend_throw_exception(php_gmagickdraw_exception_class_entry, description, (long)severity); \
 		GMAGICK_FREE_MEMORY(char *, description); \
 		DrawClearException(drawing_wand); \
 		RETURN_NULL(); \
@@ -248,7 +248,7 @@
 		} \
 		break; \
 		case IS_OBJECT: \
-			if (instanceof_function_ex(Z_OBJCE_P(param), php_gmagickpixel_sc_entry, 0 TSRMLS_CC)) { \
+			if (instanceof_function_ex(Z_OBJCE_P(param), php_gmagickpixel_sc_entry, 0)) { \
 				internp = Z_GMAGICKPIXEL_OBJ_P(param); \
 			} else { \
 				GMAGICK_THROW_EXCEPTION_WITH_MESSAGE(caller, "The parameter must be an instance of GmagickPixel or a string", (long)caller); \
@@ -267,7 +267,7 @@
 		if (strlen(filename) > MAXPATHLEN) { \
 			status = GMAGICK_READ_WRITE_FILENAME_TOO_LONG; \
 		} \
-		if (php_check_open_basedir_ex(filename, 0 TSRMLS_CC)) { \
+		if (php_check_open_basedir_ex(filename, 0)) { \
 			status = GMAGICK_READ_WRITE_OPEN_BASEDIR_ERROR; \
 		} \
 	} \
@@ -281,7 +281,7 @@
 		if (PG(safe_mode) && (!php_checkuid_ex(filename, NULL, CHECKUID_CHECK_FILE_AND_DIR, CHECKUID_NO_ERRORS))) { \
 			status = GMAGICK_READ_WRITE_SAFE_MODE_ERROR; \
 		} \
-		if (php_check_open_basedir_ex(filename, 0 TSRMLS_CC)) { \
+		if (php_check_open_basedir_ex(filename, 0)) { \
 			status = GMAGICK_READ_WRITE_OPEN_BASEDIR_ERROR; \
 		} \
 	} \
@@ -296,14 +296,14 @@
 			/* No error */\
 		break;\
 		case 1:\
-			zend_throw_exception_ex(php_gmagickdraw_exception_class_entry, 1 TSRMLS_CC, "Safe mode restricts user to read file: %s", filename);\
+			zend_throw_exception_ex(php_gmagickdraw_exception_class_entry, 1, "Safe mode restricts user to read file: %s", filename);\
 			if (free == GMAGICK_FREE_FILENAME) { \
 				 efree(filename); \
 			}\
 			RETURN_NULL();\
 		break;\
 		case 2:\
-			zend_throw_exception_ex(php_gmagickdraw_exception_class_entry, 1 TSRMLS_CC, "open_basedir restriction in effect. File(%s) is not within the allowed path(s)", filename);\
+			zend_throw_exception_ex(php_gmagickdraw_exception_class_entry, 1, "open_basedir restriction in effect. File(%s) is not within the allowed path(s)", filename);\
 			if (free == GMAGICK_FREE_FILENAME) { \
 				 efree(filename); \
 			}\
@@ -333,7 +333,7 @@
 		} \
 		break; \
 		case IS_OBJECT: \
-			if (instanceof_function_ex(Z_OBJCE_P(param), php_gmagickpixel_sc_entry, 0 TSRMLS_CC)) { \
+			if (instanceof_function_ex(Z_OBJCE_P(param), php_gmagickpixel_sc_entry, 0)) { \
 				internp = Z_GMAGICKPIXEL_OBJ_P(param); \
 			} else { \
 				GMAGICK_THROW_EXCEPTION_WITH_MESSAGE(caller, "The parameter must be an instance of GmagickPixel or a string", (long)caller); \
@@ -348,7 +348,7 @@
 /* {{{ GMAGICK_SAFEMODE_OPENBASEDIR_CHECK(filename) */
 #if PHP_VERSION_ID > 50399
 #define GMAGICK_SAFEMODE_OPENBASEDIR_CHECK(filename) \
-	if (php_check_open_basedir_ex(filename, 0 TSRMLS_CC)) { \
+	if (php_check_open_basedir_ex(filename, 0)) { \
 		zend_error(E_WARNING, "open_basedir restriction in effect "); \
 		return;	\
 	}\
@@ -359,7 +359,7 @@
 		zend_error(E_WARNING, "SAFE MODE restriction in effect "); \
 		return; \
 	} \
-	if (php_check_open_basedir_ex(filename, 0 TSRMLS_CC)) { \
+	if (php_check_open_basedir_ex(filename, 0)) { \
 		zend_error(E_WARNING, "open_basedir restriction in effect "); \
 		return;	\
 	}\


### PR DESCRIPTION
According to https://bugs.php.net/bug.php?id=80106#1600093058 the `TSRM*` macros need to be removed for PHP 8.0 compatibility.

I was not yet able to test these changes.