### PR TITLE
fix param order in test

### DIFF
--- a/tests/gmagick-003-resize_variations.phpt
+++ b/tests/gmagick-003-resize_variations.phpt
@@ -8,9 +8,9 @@ if(!extension_loaded('gmagick')) die('skip');
 --FILE--
 <?php
 $gm = new Gmagick("magick:rose");
-$gm->resizeImage(10, 10, 0.5, Gmagick::FILTER_LANCZOS);
-$gm->resizeImage(10, 10, 0.5, Gmagick::FILTER_UNDEFINED, true);
-$gm->resizeImage(10, 10, 0.5, Gmagick::FILTER_GAUSSIAN, false);
+$gm->resizeImage(10, 10, Gmagick::FILTER_LANCZOS, 0.5);
+$gm->resizeImage(10, 10, Gmagick::FILTER_UNDEFINED, 0.5, true);
+$gm->resizeImage(10, 10, Gmagick::FILTER_GAUSSIAN, 0.5, false);
 echo "ok";
 ?>
 --EXPECTF--


### PR DESCRIPTION
php 8.1.0alpha1 detects this

```
TEST 6/186 [tests/gmagick-003-resize_variations.phpt]
========DIFF========
001+ Deprecated: Implicit conversion from float 0.5 to int loses precision in /dev/shm/BUILD/php81-php-pecl-gmagick-2.0.6~RC1/NTS/tests/gmagick-003-resize_variations.php on line 3
002+ 
003+ Deprecated: Implicit conversion from float 0.5 to int loses precision in /dev/shm/BUILD/php81-php-pecl-gmagick-2.0.6~RC1/NTS/tests/gmagick-003-resize_variations.php on line 4
004+ 
005+ Deprecated: Implicit conversion from float 0.5 to int loses precision in /dev/shm/BUILD/php81-php-pecl-gmagick-2.0.6~RC1/NTS/tests/gmagick-003-resize_variations.php on line 5
     ok
========DONE========
FAIL Test resize [tests/gmagick-003-resize_variations.phpt] 

```