### PR TITLE
Fix incompatible pointer types (32-bit) - and fix for PHP 8.5

### DIFF
--- a/gmagick.c
+++ b/gmagick.c
@@ -272,11 +272,11 @@ PHP_MINIT_FUNCTION(gmagick)
 
 	/* Exception */
 	INIT_CLASS_ENTRY(ce, "GmagickException", NULL);
-	php_gmagick_exception_class_entry = zend_register_internal_class_ex(&ce, zend_exception_get_default());
+	php_gmagick_exception_class_entry = zend_register_internal_class_ex(&ce, zend_ce_exception);
 	php_gmagick_exception_class_entry->ce_flags |= ZEND_ACC_FINAL;
 
 	INIT_CLASS_ENTRY(ce, "GmagickPixelException", NULL);
-	php_gmagickpixel_exception_class_entry = zend_register_internal_class_ex(&ce, zend_exception_get_default());
+	php_gmagickpixel_exception_class_entry = zend_register_internal_class_ex(&ce, zend_ce_exception);
 	php_gmagickpixel_exception_class_entry->ce_flags |= ZEND_ACC_FINAL;
 
 	/* Class entry */

--- a/gmagick_methods.c
+++ b/gmagick_methods.c
@@ -4975,7 +4975,7 @@ PHP_METHOD(Gmagick, getimagechannelextrema)
 {
 	php_gmagick_object *intern;
 	long channel_type;
-	size_t minima, maxima;
+	unsigned long minima, maxima;
 	unsigned int status;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &channel_type) == FAILURE) {

--- a/gmagickdraw_methods.c
+++ b/gmagickdraw_methods.c
@@ -1409,7 +1409,7 @@ static zend_bool php_gmagick_check_font(char *font, int font_len TSRMLS_DC)
 	zend_bool retval = 0;
 	char **fonts;
 	unsigned long i = 0;
-	size_t num_fonts = 0;
+	unsigned long num_fonts = 0;
 
 	/* Check that user is only able to set a proper font */
 	fonts = MagickQueryFonts("*", &num_fonts);


### PR DESCRIPTION
Raised as error with GCC 14 on Fedora 40

See https://kojipkgs.fedoraproject.org//work/tasks/9956/112369956/build.log

```
/builddir/build/BUILD/php-pecl-gmagick-2.0.6~RC1/gmagick-2.0.6RC1/gmagickdraw_methods.c: In function 'php_gmagick_check_font':
/builddir/build/BUILD/php-pecl-gmagick-2.0.6~RC1/gmagick-2.0.6RC1/gmagickdraw_methods.c:1415:39: error: passing argument 2 of 'MagickQueryFonts' from incompatible pointer type [-Wincompatible-pointer-types]
 1415 |         fonts = MagickQueryFonts("*", &num_fonts);
      |                                       ^~~~~~~~~~
      |                                       |
      |                                       size_t * {aka unsigned int *}
In file included from /usr/include/GraphicsMagick/wand/wand_api.h:41,
                 from /builddir/build/BUILD/php-pecl-gmagick-2.0.6~RC1/gmagick-2.0.6RC1/php_gmagick.h:42,
                 from /builddir/build/BUILD/php-pecl-gmagick-2.0.6~RC1/gmagick-2.0.6RC1/gmagickdraw_methods.c:20:
/usr/include/GraphicsMagick/wand/magick_wand.h:64:35: note: expected 'long unsigned int *' but argument is of type 'size_t *' {aka 'unsigned int *'}
   64 |   **MagickQueryFonts(const char *,unsigned long *),
      |                                   ^~~~~~~~~~~~~~~
make: *** [Makefile:219: gmagickdraw_methods.lo] Error 1
make: *** Waiting for unfinished jobs....
/builddir/build/BUILD/php-pecl-gmagick-2.0.6~RC1/gmagick-2.0.6RC1/gmagick_methods.c: In function 'zim_Gmagick_getimagechannelextrema':
/builddir/build/BUILD/php-pecl-gmagick-2.0.6~RC1/gmagick-2.0.6RC1/gmagick_methods.c:4988:82: error: passing argument 3 of 'MagickGetImageChannelExtrema' from incompatible pointer type [-Wincompatible-pointer-types]
 4988 |         status = MagickGetImageChannelExtrema(intern->magick_wand, channel_type, &minima, &maxima);
      |                                                                                  ^~~~~~~
      |                                                                                  |
      |                                                                                  size_t * {aka unsigned int *}
In file included from /usr/include/GraphicsMagick/wand/wand_api.h:41,
                 from /builddir/build/BUILD/php-pecl-gmagick-2.0.6~RC1/gmagick-2.0.6RC1/php_gmagick.h:42,
                 from /builddir/build/BUILD/php-pecl-gmagick-2.0.6~RC1/gmagick-2.0.6RC1/gmagick_methods.c:20:
/usr/include/GraphicsMagick/wand/magick_wand.h:201:63: note: expected 'long unsigned int *' but argument is of type 'size_t *' {aka 'unsigned int *'}
  201 |   MagickGetImageChannelExtrema(MagickWand *,const ChannelType,unsigned long *,
      |                                                               ^~~~~~~~~~~~~~~
/builddir/build/BUILD/php-pecl-gmagick-2.0.6~RC1/gmagick-2.0.6RC1/gmagick_methods.c:4988:91: error: passing argument 4 of 'MagickGetImageChannelExtrema' from incompatible pointer type [-Wincompatible-pointer-types]
 4988 |         status = MagickGetImageChannelExtrema(intern->magick_wand, channel_type, &minima, &maxima);
      |                                                                                           ^~~~~~~
      |                                                                                           |
      |                                                                                           size_t * {aka unsigned int *}
/usr/include/GraphicsMagick/wand/magick_wand.h:202:5: note: expected 'long unsigned int *' but argument is of type 'size_t *' {aka 'unsigned int *'}
  202 |     unsigned long *),
      |     ^~~~~~~~~~~~~~~

```